### PR TITLE
routes to blank standings page

### DIFF
--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -1,4 +1,3 @@
 class StandingsController < ApplicationController
-  def index
-  end
+  def index; end
 end

--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -1,0 +1,4 @@
+class StandingsController < ApplicationController
+  def index
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,4 @@
 <% if current_user %>
   <p><%= link_to 'My Picks', {controller: :picks, action: :index}, method: :get %></p>
+  <p><%= link_to 'Standings', {controller: :standings, action: :index}, method: :get %></p>
 <% end %>

--- a/app/views/standings/index.html.erb
+++ b/app/views/standings/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Standings</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   root to: 'home#index'
   resources :picks, only: %i[index new create]
+  resources :standings, only: %i[index]
 end


### PR DESCRIPTION
the index page now links to the standings page, but the standings page is currently blank.

I tried to just get it to print usernames of all users, but I couldn't get it to work and I figured you'd be able to get something up and running a lot more quickly