### PR TITLE
Only allow admins on admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  username               :string           not null, indexed
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  admin                  :boolean          default(FALSE), not null
 #
 class User < ApplicationRecord
   # Include default devise modules. Others available are:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+
+  authenticate :user, lambda { |u| u.admin? } do
+    mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   root to: 'home#index'

--- a/db/migrate/20210930031815_add_admin_to_user.rb
+++ b/db/migrate/20210930031815_add_admin_to_user.rb
@@ -1,0 +1,5 @@
+class AddAdminToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_21_015529) do
+ActiveRecord::Schema.define(version: 2021_09_30_031815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_015529) do
     t.string "username", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
I did this as a new separate migration because the existing user migration was autogenerated by devise and I want to leave that as is.