### PR TITLE
Fix ranks and sorting with refactor

### DIFF
--- a/app/controllers/round_controller.rb
+++ b/app/controllers/round_controller.rb
@@ -20,9 +20,7 @@ class RoundController < ApplicationController
     @round_name = @matchups.first.round_name
     @num_outcomes = @matchups.first.games_needed_to_win * 2
 
-    @user_data = picks.group_by(&:user)
-                      .transform_values { |user_picks| user_picks.index_by(&:matchup_id) }
-                      .sort_by { |_u, mp| [-mp.values.map(&:max_points).sum, -mp.values.map(&:min_points).sum] }
+    @user_data = UserScores::Round.build(picks)
 
     @num_users = @user_data.length
 

--- a/app/lib/user_scores/round.rb
+++ b/app/lib/user_scores/round.rb
@@ -1,0 +1,51 @@
+module UserScores
+  class Round
+    attr_reader :user, :picks, :picks_by_matchup_id
+
+    def self.build(picks)
+      picks.group_by(&:user).map do |user, p|
+        new(user, p)
+      end.sort
+    end
+
+    def initialize(user, picks)
+      @user = user
+      @picks = picks
+      @picks_by_matchup_id = picks.index_by(&:matchup_id)
+    end
+
+    def pick_for_matchup(matchup_id)
+      picks_by_matchup_id[matchup_id]
+    end
+
+    def min_total
+      @min_total ||= picks.sum(&:min_points)
+    end
+
+    def potential_total
+      @potential_total ||= picks.sum(&:potential_points)
+    end
+
+    def max_total
+      @max_total ||= picks.sum(&:max_points)
+    end
+
+    def totals
+      [min_total, potential_total, max_total]
+    end
+
+    def <=>(other)
+      sort_key <=> other.sort_key
+    end
+
+    def rank_key
+      sort_key.first(2)
+    end
+
+    protected
+
+    def sort_key
+      [-max_total, -min_total, user.username]
+    end
+  end
+end

--- a/app/lib/user_scores/total.rb
+++ b/app/lib/user_scores/total.rb
@@ -1,0 +1,49 @@
+module UserScores
+  class Total
+    attr_reader :user, :picks, :rounds
+    attr_accessor :rank
+
+    def self.build(picks)
+      totals = picks.group_by(&:user).map do |user, p|
+        new(user, p)
+      end.sort
+
+      ranks = totals.map(&:rank_key)
+
+      totals.each { |t| t.rank = ranks.index(t.rank_key) + 1 }
+    end
+
+    def initialize(user, picks)
+      @user = user
+      @picks = picks
+      @rounds = picks.select { |p| p.matchup.started? }
+                     .group_by { |p| p.matchup.round }
+                     .transform_values do |p|
+                       Round.new(user, p)
+                     end
+      @rounds.default = OpenStruct.new(totals: [0, 0, 0])
+    end
+
+    def min_total
+      @rounds.values.sum(&:min_total)
+    end
+
+    def max_total
+      @rounds.values.sum(&:max_total)
+    end
+
+    def <=>(other)
+      sort_key <=> other.sort_key
+    end
+
+    def rank_key
+      [max_total, min_total]
+    end
+
+    protected
+
+    def sort_key
+      [-max_total, -min_total, user.username]
+    end
+  end
+end

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -1,4 +1,4 @@
-<% pick = picks_by_matchup_id[matchup.id] %>
+<% pick = user_round.picks_by_matchup_id[matchup.id] %>
 <% if pick %>
   <td class="<%= class_names(:'text-center', 'table-secondary': !pick.winner_is_favorite)%>" style="white-space: nowrap;">
     <%= pick.winner.name %>

--- a/app/views/round/_user_row.html.erb
+++ b/app/views/round/_user_row.html.erb
@@ -1,5 +1,4 @@
-<% user, picks_by_matchup_id = user_row %>
 <tr>
-  <%= render partial: 'shared/user_cell', locals: {user: user} %>
-  <%= render partial: 'round/pick_cell', collection: @matchups, as: :matchup, locals: {picks_by_matchup_id: picks_by_matchup_id}, spacer_template: 'shared/empty_cell' %>
+  <%= render partial: 'shared/user_cell', locals: {user: user_round.user} %>
+  <%= render partial: 'round/pick_cell', collection: @matchups, as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/show.html.erb
+++ b/app/views/round/show.html.erb
@@ -8,7 +8,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'round/user_row', collection: @user_data %>
+      <%= render partial: 'round/user_row', collection: @user_data, as: :user_round %>
     </tbody>
     <tfoot>
       <%= render partial: 'round/matchup_summary_row', collection: (0...@num_outcomes).to_a, as: :outcome %>

--- a/app/views/standings/_numbers_table.html.erb
+++ b/app/views/standings/_numbers_table.html.erb
@@ -25,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'standings/user_numbers_row', collection: @data, as: :user_data %>
+      <%= render partial: 'standings/user_numbers_row', collection: @data, as: :user_totals %>
     </tbody>
   </table>
 </div>

--- a/app/views/standings/_progress_table.html.erb
+++ b/app/views/standings/_progress_table.html.erb
@@ -8,7 +8,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'standings/user_progress_row', collection: @data, as: :user_data %>
+      <%= render partial: 'standings/user_progress_row', collection: @data, as: :user_totals %>
     </tbody>
   </table>
 </div>

--- a/app/views/standings/_user_numbers_row.html.erb
+++ b/app/views/standings/_user_numbers_row.html.erb
@@ -1,13 +1,11 @@
-<% user, round_scores, totals, rank = user_data %>
 <tr>
-  <td><%= rank %></td>
-  <%= render partial: 'shared/user_cell', locals: {user: user} %>
+  <td><%= user_totals.rank %></td>
+  <%= render partial: 'shared/user_cell', locals: {user: user_totals.user} %>
   <% @rounds.each do |round| %>
-    <% min, _potential, max = round_scores[round] %>
+    <% min, _p, max = user_totals.rounds[round].totals %>
     <%= render partial: 'standings/score_cell', locals: {min: min, max: max} %>
     <td></td>
     <td></td>
   <% end %>
-  <% min, max = totals %>
-  <%= render partial: 'standings/score_cell', locals: {min: min, max: max} %>
+  <%= render partial: 'standings/score_cell', locals: {min: user_totals.min_total, max: user_totals.max_total} %>
 </tr>

--- a/app/views/standings/_user_progress_row.html.erb
+++ b/app/views/standings/_user_progress_row.html.erb
@@ -1,12 +1,10 @@
-<% user, round_scores, totals, rank = user_data %>
 <tr>
-  <td><%= rank %></td>
-  <%= render partial: 'shared/user_cell', locals: {user: user} %>
-  <% min, max = totals %>
+  <td><%= user_totals.rank %></td>
+  <%= render partial: 'shared/user_cell', locals: {user: user_totals.user} %>
   <td class="align-middle">
     <div class="progress bg-secondary" style="--bs-bg-opacity: .15;">
       <% @rounds.each do |round| %>
-        <% min, potential, max = round_scores[round] %>
+        <% min, potential, max = user_totals.rounds[round].totals %>
         <% bg = @bg_colors[round] %>
         <% round_name = @round_names[round] %>
         <% if min.positive? %>


### PR DESCRIPTION
Encapsulate the results of a user for a round in `UserScores::Round` and the results of a user for the standings in `UserScores::Total` (which uses the former). Cuts down on repetition between standings and rounds (especially in the future when I add the round totals to the round page) and makes the data structures easy to follow.

I fixed the ranking and sorting as part of the new classes.