### PR TITLE
Fix score bars when sweep is no longer possible

### DIFF
--- a/app/lib/user_scores/round.rb
+++ b/app/lib/user_scores/round.rb
@@ -1,14 +1,17 @@
 module UserScores
   class Round < Base
     attr_reader :picks_by_matchup_id
-    attr_accessor :max_available
+    attr_accessor :max_possible_round_total, :biggest_matchup_max_possible
 
     def self.build(picks)
       scores = super(picks)
 
-      max_available = picks.map(&:matchup).uniq.sum(&:max_available_points)
+      max_possibles = picks.map(&:matchup).uniq.map(&:max_possible_points)
+      biggest_matchup_max_possible = max_possibles.max
+      max_possible_round_total = max_possibles.sum
       scores.each do |s|
-        s.max_available = max_available
+        s.max_possible_round_total = max_possible_round_total
+        s.biggest_matchup_max_possible = biggest_matchup_max_possible
       end
     end
 
@@ -38,11 +41,11 @@ module UserScores
     end
 
     def min_total_percentage
-      min_total.to_f / max_available
+      min_total.to_f / max_possible_round_total
     end
 
     def potential_total_percentage
-      potential_total.to_f / max_available
+      potential_total.to_f / max_possible_round_total
     end
 
     def points_tooltip

--- a/app/models/matchup.rb
+++ b/app/models/matchup.rb
@@ -167,8 +167,8 @@ class Matchup < ApplicationRecord
     end
   end
 
-  def max_available_points
-    all_scores.flatten.max
+  def max_possible_points
+    possible_scores.flatten.max
   end
 
   def possible_scores

--- a/app/models/pick.rb
+++ b/app/models/pick.rb
@@ -60,15 +60,15 @@ class Pick < ApplicationRecord
   end
 
   def min_points_percentage
-    min_points.to_f / matchup.max_available_points
+    min_points.to_f / matchup.max_possible_points
   end
 
   def max_points_percentage
-    max_points.to_f / matchup.max_available_points
+    max_points.to_f / matchup.max_possible_points
   end
 
   def potential_points_percentage
-    potential_points.to_f / matchup.max_available_points
+    potential_points.to_f / matchup.max_possible_points
   end
 
   def points_tooltip

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -7,7 +7,8 @@
     in <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;">
-    <div class="progress bg-secondary" style="--bs-bg-opacity: .15;" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
+    <% width = (matchup.max_possible_points * 100.0 / user_round.biggest_matchup_max_possible).round(4) %>
+    <div class="progress bg-secondary" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
       <% if pick.min_points.positive? %>
         <% pct = (pick.min_points_percentage * 100).round(4) %>
         <div class="progress-bar <%= @bg_color %>" role="progressbar" style="width: <%= pct %>%">


### PR DESCRIPTION
Fixes #66 
The max value of the bars is adjusted to the maximum possible given the series results that are still possible. And the bars are scaled down as needed to keep the scale the same for all the matchups in a round.