### PR TITLE
Only show Change Picks when appropriate

### DIFF
--- a/app/controllers/picks_controller.rb
+++ b/app/controllers/picks_controller.rb
@@ -10,7 +10,8 @@ class PicksController < ApplicationController
                               .order(:starts_at)
                               .group_by(&:round)
 
-    @accepting_picks = matchups.accepting_entries.exists?
+    @can_change_picks = @picks.any? { |pick| pick.matchup.accepting_entries? }
+    @accepting_picks = @can_change_picks || @other_matchups.any?
     @picks = @picks.group_by { |pick| pick.matchup.round }
   end
 

--- a/app/models/matchup.rb
+++ b/app/models/matchup.rb
@@ -62,6 +62,10 @@ class Matchup < ApplicationRecord
   scope :started, -> { where(starts_at: ...Time.current) }
   scope :current_season, -> { where(CurrentSeason.params) }
 
+  def accepting_entries?
+    !started?
+  end
+
   def started?
     starts_at.past?
   end

--- a/app/views/picks/index.html.erb
+++ b/app/views/picks/index.html.erb
@@ -43,7 +43,7 @@
 <% if @picks.empty? %>
   <p>You haven't made any picks.</p>
 <% end %>
-<% if @accepting_picks && @picks.any? %>
+<% if @can_change_picks %>
   <p>
     <%= button_to 'Change Picks', {action: :new}, method: :get, class: "btn btn-primary" %>
   </p>

--- a/spec/controllers/picks_controller_spec.rb
+++ b/spec/controllers/picks_controller_spec.rb
@@ -21,6 +21,7 @@ describe PicksController, type: :controller do
         expect(assigns(:picks)).to eql({})
         expect(assigns(:other_matchups)).to be_empty
         expect(assigns(:accepting_picks)).to be false
+        expect(assigns(:can_change_picks)).to be false
       end
     end
 
@@ -40,6 +41,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({})
             expect(assigns(:other_matchups)).to eql(1 => accepting_entries)
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be false
           end
         end
 
@@ -51,6 +53,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({1 => [pick]})
             expect(assigns(:other_matchups)).to eql(1 => [accepting_entries.last])
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be true
           end
         end
 
@@ -66,6 +69,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({1 => picks})
             expect(assigns(:other_matchups)).to eql({})
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be true
           end
         end
       end
@@ -91,6 +95,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({1 => old_picks})
             expect(assigns(:other_matchups)).to eql(2 => accepting_entries)
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be false
           end
         end
 
@@ -102,6 +107,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({1 => old_picks, 2 => [pick]})
             expect(assigns(:other_matchups)).to eql(2 => [accepting_entries.last])
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be true
           end
         end
 
@@ -117,6 +123,7 @@ describe PicksController, type: :controller do
             expect(assigns(:picks)).to eql({1 => old_picks, 2 => picks})
             expect(assigns(:other_matchups)).to eql({})
             expect(assigns(:accepting_picks)).to be true
+            expect(assigns(:can_change_picks)).to be true
           end
         end
       end


### PR DESCRIPTION
The Change Picks button was visible when it shouldn't be: When there were matchups accepting entries and the user had some picks, regardless of whether any of their picks were for the matchups accepting entries.