### PR TITLE
Automatically create and update matchups from NBA API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem "rails_admin", "~> 2.0"
 
 gem "postmark-rails"
 
+gem "faraday", "~> 2.8"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,11 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ffi (1.16.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -289,6 +294,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -375,6 +381,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_bot_rails
+  faraday (~> 2.8)
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/lib/sync/nba/client.rb
+++ b/app/lib/sync/nba/client.rb
@@ -1,0 +1,42 @@
+module Sync
+  module Nba
+    class Client
+      def self.fetch_bracket(year)
+        new(year).fetch_bracket
+      end
+
+      def initialize(year)
+        @year = year
+      end
+
+      def fetch_bracket
+        connection.get
+      end
+
+      private
+
+      attr_reader :year
+
+      def connection
+        @connection ||= Faraday.new(url: url) do |f|
+          f.response :json, content_type: content_types, parser_options: {symbolize_names: true}
+          f.response :raise_error
+        end
+      end
+
+      def url
+        url ||= "https://cdn.nba.com/static/json/staticData/brackets/#{year - 1}/PlayoffBracket.json"
+      end
+
+      # nba.com currently sends this as text/plain rather than application/json, so we must
+      # explicitly tell faraday to parse that content type as json. The regex is the default
+      # value that faraday uses, so we will include that for maximum compatibility.
+      def content_types
+        [
+          "text/plain",
+          /\bjson$/
+        ]
+      end
+    end
+  end
+end

--- a/app/lib/sync/nba/client.rb
+++ b/app/lib/sync/nba/client.rb
@@ -10,7 +10,7 @@ module Sync
       end
 
       def fetch_bracket
-        connection.get
+        connection.get.body
       end
 
       private
@@ -24,6 +24,7 @@ module Sync
         end
       end
 
+      # It uses the year that the season started rather than the playoff year.
       def url
         url ||= "https://cdn.nba.com/static/json/staticData/brackets/#{year - 1}/PlayoffBracket.json"
       end

--- a/app/lib/sync/nba/client.rb
+++ b/app/lib/sync/nba/client.rb
@@ -26,7 +26,7 @@ module Sync
 
       # It uses the year that the season started rather than the playoff year.
       def url
-        url ||= "https://cdn.nba.com/static/json/staticData/brackets/#{year - 1}/PlayoffBracket.json"
+        @url ||= "https://cdn.nba.com/static/json/staticData/brackets/#{year - 1}/PlayoffBracket.json"
       end
 
       # nba.com currently sends this as text/plain rather than application/json, so we must

--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -4,6 +4,7 @@ module Sync
       def self.run(year)
         bracket = Client.fetch_bracket(year)[:bracket]
         all_series = bracket[:playoffBracketSeries]
+        # The `seasonYear` in the API is the year of the season start, in the fall.
         year = bracket[:seasonYear].to_i + 1
 
         all_series.each do |series_data|
@@ -56,6 +57,7 @@ module Sync
       def find_existing_matchup
         matchup_base = Matchup.where(sport: :nba, year: year, round: round, conference: conference)
 
+        # Just to be extra careful, this looks for a matchup where the teams are reversed.
         matchup_base.find_by(favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode) ||
           matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
       end
@@ -79,9 +81,9 @@ module Sync
       def number
         case round
         when 1
-          series_data[:highSeedRank]
+          series_data[:highSeedRank].to_i
         when 2
-          case series_data[:highSeedRank]
+          case series_data[:highSeedRank].to_i
           when 1, 4, 5, 8
             1
           else

--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -57,7 +57,7 @@ module Sync
         matchup_base = Matchup.where(sport: :nba, year: year, round: round, conference: conference)
 
         matchup_base.find_by(favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode) ||
-        matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
+          matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
       end
 
       def series_started?

--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -1,0 +1,116 @@
+module Sync
+  module Nba
+    class Matchups
+      def self.run(year)
+        bracket = Client.fetch_bracket(year)[:bracket]
+        all_series = bracket[:playoffBracketSeries]
+        year = bracket[:seasonYear].to_i + 1
+
+        all_series.each do |series_data|
+          sync_matchup(year, series_data)
+        end
+      end
+
+      def self.sync_matchup(year, series_data)
+        new(year, series_data).sync_matchup
+      end
+
+      def initialize(year, series_data)
+        @year = year
+        @series_data = series_data
+      end
+
+      def sync_matchup
+        if series_started?
+          sync_wins
+        elsif teams_known?
+          create_matchup
+        end
+      end
+
+      private
+
+      attr_reader :year, :series_data
+
+      def sync_wins
+        find_existing_matchup&.update!(favorite_wins: favorite_wins, underdog_wins: underdog_wins)
+      end
+
+      def create_matchup
+        return if find_existing_matchup
+
+        Matchup.create!(
+          sport: :nba,
+          year: year,
+          round: round,
+          conference: conference,
+          number: number,
+          favorite_tricode: favorite_tricode,
+          underdog_tricode: underdog_tricode,
+          favorite_wins: favorite_wins,
+          underdog_wins: underdog_wins,
+          starts_at: starts_at
+        )
+      end
+
+      def find_existing_matchup
+        matchup_base = Matchup.where(sport: :nba, year: year, round: round, conference: conference)
+
+        matchup_base.find_by(favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode) ||
+        matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
+      end
+
+      def series_started?
+        favorite_wins > 0 || underdog_wins > 0
+      end
+
+      def teams_known?
+        favorite_tricode && underdog_tricode
+      end
+
+      def round
+        series_data[:roundNumber].to_i
+      end
+
+      def conference
+        series_data[:seriesConference].downcase
+      end
+
+      def number
+        case round
+        when 1
+          series_data[:highSeedRank]
+        when 2
+          case series_data[:highSeedRank]
+          when 1, 4, 5, 8
+            1
+          else
+            2
+          end
+        when 3, 4
+          1
+        end
+      end
+
+      def favorite_tricode
+        series_data[:highSeedTricode]&.downcase
+      end
+
+      def underdog_tricode
+        series_data[:lowSeedTricode]&.downcase
+      end
+
+      def favorite_wins
+        series_data[:highSeedSeriesWins].to_i
+      end
+
+      def underdog_wins
+        series_data[:lowSeedSeriesWins].to_i
+      end
+
+      def starts_at
+        Time.parse(series_data[:nextGameDateTimeUTC]) + 10.minutes
+      end
+    end
+  end
+end

--- a/lib/tasks/sync_matchups.rake
+++ b/lib/tasks/sync_matchups.rake
@@ -1,0 +1,6 @@
+desc "Sync Matchups from the league API, NBA only for now"
+task sync_matchups: :environment do
+  if CurrentSeason.sport == :nba
+    Sync::Nba::Matchups.run(CurrentSeason.year)
+  end
+end

--- a/spec/lib/sync/nba/client_spec.rb
+++ b/spec/lib/sync/nba/client_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Sync::Nba::Client do
+  pending
+end

--- a/spec/lib/sync/nba/matchups_spec.rb
+++ b/spec/lib/sync/nba/matchups_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Sync::Nba::Matchups do
+  pending
+end


### PR DESCRIPTION
It pulls the full playoff bracket data from [here](https://cdn.nba.com/static/json/staticData/brackets/2023/PlayoffBracket.json).

For series that haven't yet started (based on the win counts) but have both teams filled in it creates a new matchup if it doesn't exist yet. It uses the start time of the next game (i.e. the first game) for `starts_at`.

For series that have started it finds the existing matchup and updates the win counts.

The idea is to run this every 10 minutes with Heroku Scheduler.