### PR TITLE
Handle matchups where the first game time hasn't been sent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "postmark-rails"
 
 gem "faraday", "~> 2.8"
 
+gem "strong_migrations"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,8 @@ GEM
     standard-rails (0.2.0)
       lint_roller (~> 1.0)
       rubocop-rails (~> 2.20.2)
+    strong_migrations (1.8.0)
+      activerecord (>= 5.2)
     temple (0.10.2)
     thor (1.2.2)
     tilt (2.3.0)
@@ -398,6 +400,7 @@ DEPENDENCIES
   spring
   standard (~> 1.28)
   standard-rails (~> 0.2.0)
+  strong_migrations
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)

--- a/app/models/matchup.rb
+++ b/app/models/matchup.rb
@@ -18,7 +18,7 @@
 #
 class Matchup < ApplicationRecord
   validates :sport, :year, :round, :conference, :number, :favorite_tricode, :underdog_tricode,
-    :favorite_wins, :underdog_wins, :starts_at, presence: true
+    :favorite_wins, :underdog_wins, presence: true
 
   validates :year, numericality: {greater_than_or_equal_to: 2021, less_than_or_equal_to: Date.current.year}
 
@@ -58,7 +58,7 @@ class Matchup < ApplicationRecord
   enum favorite_tricode: Team.tricodes_for_enum, _prefix: :favorite
   enum underdog_tricode: Team.tricodes_for_enum, _prefix: :underdog
 
-  scope :accepting_entries, -> { where(starts_at: Time.current...) }
+  scope :accepting_entries, -> { where(starts_at: Time.current...).or(where(starts_at: nil)) }
   scope :started, -> { where(starts_at: ...Time.current) }
   scope :current_season, -> { where(CurrentSeason.params) }
 
@@ -67,12 +67,13 @@ class Matchup < ApplicationRecord
   end
 
   def started?
-    starts_at.past?
+    starts_at&.past? || false
   end
 
   def starts_at_pretty
-    starts_at.in_time_zone("America/New_York")
-      .strftime("%a %-d %b, %l:%M %p %Z")
+    starts_at&.in_time_zone("America/New_York")
+      &.strftime("%a %-d %b, %l:%M %p %Z") ||
+      "?"
   end
 
   def favorite

--- a/app/models/matchup.rb
+++ b/app/models/matchup.rb
@@ -12,7 +12,7 @@
 #  underdog_tricode :text             not null
 #  favorite_wins    :integer          default(0), not null
 #  underdog_wins    :integer          default(0), not null
-#  starts_at        :datetime         not null
+#  starts_at        :datetime
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20240507132638
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true

--- a/db/migrate/20240507132902_change_starts_at_to_nullable.rb
+++ b/db/migrate/20240507132902_change_starts_at_to_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeStartsAtToNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :matchups, :starts_at, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_24_023204) do
+ActiveRecord::Schema.define(version: 2024_05_07_132902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2021_10_24_023204) do
     t.text "underdog_tricode", null: false
     t.integer "favorite_wins", default: 0, null: false
     t.integer "underdog_wins", default: 0, null: false
-    t.datetime "starts_at", null: false
+    t.datetime "starts_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["sport", "year", "round", "conference", "number"], name: "index_matchups_uniquely", unique: true

--- a/spec/controllers/picks_controller_spec.rb
+++ b/spec/controllers/picks_controller_spec.rb
@@ -27,9 +27,10 @@ describe PicksController, type: :controller do
 
     context "when there are matchups" do
       let!(:accepting_entries) do
-        (1..2).map do |n|
-          create :matchup, CurrentSeason.sport, :accepting_entries, round: round, number: n, **CurrentSeason.params
-        end
+        [
+          create(:matchup, CurrentSeason.sport, :accepting_entries, round: round, number: 1, **CurrentSeason.params),
+          create(:matchup, CurrentSeason.sport, :accepting_entries, round: round, number: 2, starts_at: nil, **CurrentSeason.params)
+        ]
       end
 
       context "when in the first round" do

--- a/spec/lib/sync/nba/matchups_spec.rb
+++ b/spec/lib/sync/nba/matchups_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Sync::Nba::Matchups do
         let(:starts_at) { next_game_at + 10.minutes if next_game_at }
 
         context "when there's no existing matchup" do
-
           shared_examples_for "creates matchup" do
             it "creates a matchup" do
               subject
@@ -150,7 +149,7 @@ RSpec.describe Sync::Nba::Matchups do
       let(:number) { favorite_seed }
       let(:favorite_tricode) { "nyk" }
       let(:underdog_tricode) { "bos" }
-      let!(:other_matchup) { create :matchup, year: year, round: 1, conference: "east", number: 2, favorite_tricode: "atl", underdog_tricode: "phi"}
+      let!(:other_matchup) { create :matchup, year: year, round: 1, conference: "east", number: 2, favorite_tricode: "atl", underdog_tricode: "phi" }
 
       it_behaves_like "syncing"
     end
@@ -163,7 +162,7 @@ RSpec.describe Sync::Nba::Matchups do
       let(:number) { 2 }
       let(:favorite_tricode) { "gsw" }
       let(:underdog_tricode) { "lal" }
-      let!(:other_matchup) { create :matchup, year: year, round: 2, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+      let!(:other_matchup) { create :matchup, year: year, round: 2, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal" }
 
       it_behaves_like "syncing"
     end
@@ -176,7 +175,7 @@ RSpec.describe Sync::Nba::Matchups do
       let(:number) { 1 }
       let(:favorite_tricode) { "nyk" }
       let(:underdog_tricode) { "bos" }
-      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal" }
 
       it_behaves_like "syncing"
     end
@@ -189,7 +188,7 @@ RSpec.describe Sync::Nba::Matchups do
       let(:number) { 1 }
       let(:favorite_tricode) { "nyk" }
       let(:underdog_tricode) { "gsw" }
-      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal" }
 
       it_behaves_like "syncing"
     end

--- a/spec/lib/sync/nba/matchups_spec.rb
+++ b/spec/lib/sync/nba/matchups_spec.rb
@@ -1,5 +1,197 @@
 require "rails_helper"
 
 RSpec.describe Sync::Nba::Matchups do
-  pending
+  describe "#sync_matchup" do
+    subject { instance.sync_matchup }
+    let(:instance) { described_class.new(year, series_data) }
+
+    let(:year) { 2024 }
+    let(:series_data) do
+      {
+        roundNumber: round_number,
+        seriesConference: series_conference,
+        highSeedRank: favorite_seed,
+        highSeedTricode: favorite_tricode.to_s.upcase,
+        lowSeedTricode: underdog_tricode.to_s.upcase,
+        highSeedSeriesWins: favorite_wins,
+        lowSeedSeriesWins: underdog_wins,
+        nextGameDateTimeUTC: next_game_at_pretty
+      }
+    end
+
+    let(:next_game_at_pretty) { next_game_at&.strftime("%FT%TZ") }
+    let(:next_game_at) { 1.day.from_now.beginning_of_hour }
+
+    let(:expected_attributes) do
+      {
+        sport: "nba",
+        year: year,
+        round: round_number,
+        conference: conference,
+        number: number,
+        favorite_tricode: favorite_tricode,
+        underdog_tricode: underdog_tricode,
+        favorite_wins: favorite_wins,
+        underdog_wins: underdog_wins,
+        starts_at: starts_at
+      }
+    end
+
+    shared_examples_for "syncing" do
+      context "when the series hasn't started yet" do
+        let(:favorite_wins) { 0 }
+        let(:underdog_wins) { 0 }
+        let(:starts_at) { next_game_at + 10.minutes if next_game_at }
+
+        context "when there's no existing matchup" do
+
+          shared_examples_for "creates matchup" do
+            it "creates a matchup" do
+              subject
+              expect(Matchup.count).to eql(2)
+              matchup = Matchup.last
+
+              expect(matchup).to have_attributes(expected_attributes)
+            end
+          end
+
+          context "when the first game is unknown" do
+            let(:next_game_at) { nil }
+            it_behaves_like "creates matchup"
+          end
+
+          context "when the first game is known" do
+            it_behaves_like "creates matchup"
+          end
+        end
+
+        context "when there's an existing matchup" do
+          let!(:matchup) do
+            create :matchup, year: year, round: round_number, conference: conference, number: number,
+              favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode,
+              favorite_wins: favorite_wins, underdog_wins: underdog_wins, starts_at: initial_starts_at
+          end
+
+          context "when there's starts_at and no next_game_at" do
+            let(:initial_starts_at) { nil }
+            let(:next_game_at) { nil }
+
+            it "does nothing" do
+              expect(Matchup.count).to eql(2)
+              subject
+              expect(Matchup.count).to eql(2)
+              expect(matchup.reload).to have_attributes(expected_attributes)
+              expect(matchup.starts_at).to be_nil
+            end
+          end
+
+          context "when there's no initial starts_at and there is a next game" do
+            let(:initial_starts_at) { nil }
+            let(:next_game_at) { 1.day.from_now.beginning_of_hour }
+            it "updates starts_at" do
+              expect(Matchup.count).to eql(2)
+              subject
+              expect(Matchup.count).to eql(2)
+              expect(matchup.reload).to have_attributes(expected_attributes)
+              expect(matchup.starts_at).to be_present
+            end
+          end
+
+          context "when there's an initial starts_at and the next game is different" do
+            let(:initial_starts_at) { 1.day.from_now.beginning_of_hour }
+            let(:next_game_at) { 2.days.from_now.beginning_of_hour }
+            let(:starts_at) { initial_starts_at }
+            it "does not update starts_at" do
+              expect(Matchup.count).to eql(2)
+              subject
+              expect(Matchup.count).to eql(2)
+              expect(matchup.reload).to have_attributes(expected_attributes)
+              expect(matchup.starts_at).to be_present
+            end
+          end
+        end
+      end
+
+      context "when the series has started" do
+        let(:favorite_wins) { 1 }
+        let(:underdog_wins) { 1 }
+
+        context "when the matchup isn't found" do
+          it "does nothing" do
+            expect(Matchup.count).to eql(1)
+            subject
+            expect(Matchup.count).to eql(1)
+          end
+        end
+
+        context "when the matchup is found" do
+          let!(:matchup) do
+            create :matchup, year: year, round: round_number, conference: conference, number: number,
+              favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode,
+              favorite_wins: 0, underdog_wins: 0, starts_at: starts_at
+          end
+          let(:starts_at) { next_game_at - 1.hour }
+
+          it "updates the wins and not starts_at" do
+            expect(Matchup.count).to eql(2)
+            subject
+            expect(Matchup.count).to eql(2)
+            expect(matchup.reload).to have_attributes(expected_attributes)
+          end
+        end
+      end
+    end
+
+    context "when it's the east first round" do
+      let(:round_number) { 1 }
+      let(:series_conference) { "East" }
+      let(:conference) { "east" }
+      let(:favorite_seed) { 3 }
+      let(:number) { favorite_seed }
+      let(:favorite_tricode) { "nyk" }
+      let(:underdog_tricode) { "bos" }
+      let!(:other_matchup) { create :matchup, year: year, round: 1, conference: "east", number: 2, favorite_tricode: "atl", underdog_tricode: "phi"}
+
+      it_behaves_like "syncing"
+    end
+
+    context "when it's the west second round" do
+      let(:round_number) { 2 }
+      let(:series_conference) { "West" }
+      let(:conference) { "west" }
+      let(:favorite_seed) { 3 }
+      let(:number) { 2 }
+      let(:favorite_tricode) { "gsw" }
+      let(:underdog_tricode) { "lal" }
+      let!(:other_matchup) { create :matchup, year: year, round: 2, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+
+      it_behaves_like "syncing"
+    end
+
+    context "when it's the east third round" do
+      let(:round_number) { 3 }
+      let(:series_conference) { "East" }
+      let(:conference) { "east" }
+      let(:favorite_seed) { 8 }
+      let(:number) { 1 }
+      let(:favorite_tricode) { "nyk" }
+      let(:underdog_tricode) { "bos" }
+      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+
+      it_behaves_like "syncing"
+    end
+
+    context "when it's the finals" do
+      let(:round_number) { 4 }
+      let(:series_conference) { "NBA Finals" }
+      let(:conference) { "finals" }
+      let(:favorite_seed) { 8 }
+      let(:number) { 1 }
+      let(:favorite_tricode) { "nyk" }
+      let(:underdog_tricode) { "gsw" }
+      let!(:other_matchup) { create :matchup, year: year, round: 3, conference: "west", number: 1, favorite_tricode: "lac", underdog_tricode: "dal"}
+
+      it_behaves_like "syncing"
+    end
+  end
 end

--- a/spec/models/matchup_spec.rb
+++ b/spec/models/matchup_spec.rb
@@ -16,21 +16,65 @@ RSpec.describe Matchup, type: :model do
   describe "::accepting_entries" do
     subject { described_class.accepting_entries }
 
-    let!(:future) { 2.times.map { |n| create :matchup, starts_at: 5.minutes.from_now, number: n + 1 } }
+    let!(:future) { (1..2).map { |n| create :matchup, starts_at: 5.minutes.from_now, number: n } }
+    let!(:unknown) { (3..4).map { |n| create :matchup, starts_at: nil, number: n } }
+    let!(:past) { (1..2).map { |n| create :matchup, starts_at: 5.minutes.ago, number: n, conference: :west } }
 
-    before { 2.times.map { |n| create :matchup, starts_at: 5.minutes.ago, number: n + 3 } }
-
-    it { is_expected.to match_array future }
+    it { is_expected.to match_array future + unknown }
   end
 
   describe "::started" do
     subject { described_class.started }
 
-    let!(:past) { 2.times.map { |n| create :matchup, starts_at: 5.minutes.ago, number: n + 3 } }
-
-    before { 2.times.map { |n| create :matchup, starts_at: 5.minutes.from_now, number: n + 1 } }
+    let!(:future) { (1..2).map { |n| create :matchup, starts_at: 5.minutes.from_now, number: n } }
+    let!(:unknown) { (3..4).map { |n| create :matchup, starts_at: nil, number: n } }
+    let!(:past) { (1..2).map { |n| create :matchup, starts_at: 5.minutes.ago, number: n, conference: :west } }
 
     it { is_expected.to match_array past }
+  end
+
+  describe "#started?" do
+    subject { matchup.started? }
+
+    context "when starts_at is in the future" do
+      let(:matchup) { create :matchup, starts_at: 1.minute.from_now }
+      it { should be false }
+    end
+
+    context "when starts_at is unknown" do
+      let(:matchup) { create :matchup, starts_at: nil }
+      it { should be false }
+    end
+
+    context "when starts_at is in the past" do
+      let(:matchup) { create :matchup, starts_at: 1.minute.ago }
+      it { should be true }
+    end
+  end
+
+  describe "#starts_at_pretty" do
+    subject { matchup.starts_at_pretty }
+
+    context "when starts_at is in the future" do
+      let(:matchup) { create :matchup, starts_at: 1.minute.from_now }
+      it do
+        should be_present
+        should_not eql "?"
+      end
+    end
+
+    context "when starts_at is unknown" do
+      let(:matchup) { create :matchup, starts_at: nil }
+      it { should eql "?" }
+    end
+
+    context "when starts_at is in the past" do
+      let(:matchup) { create :matchup, starts_at: 1.minute.ago }
+      it do
+        should be_present
+        should_not eql "?"
+      end
+    end
   end
 
   describe "#favorite" do


### PR DESCRIPTION
Often times the teams for a new series are set but the first game isn't yet set. This PR allows us to import those matchups and and fill in `starts_at` later, when it becomes available, so that people can start making picks before the first game is known.

In the UI it'll show "Starts ?" instead of a date.

Other things:
- I fixed the conference for importing the finals.
- Added `strong_migrations`
- Improved logging for scheduler.