### PR TITLE
Fix denominator for bar width on matchup summaries

### DIFF
--- a/app/controllers/round_controller.rb
+++ b/app/controllers/round_controller.rb
@@ -26,10 +26,12 @@ class RoundController < ApplicationController
 
     @num_users = @user_data.length
 
+    # For each matchup, count the picks for each outcome
     @matchup_data = picks.group_by(&:matchup_id)
       .transform_values do |pps|
       pps.group_by(&:scoring_index)
         .transform_values(&:length)
+        .merge(total: pps.length)
     end
 
     @bg_color = BG_COLORS[params[:round].to_i]

--- a/app/views/round/_matchup_summary_entry.html.erb
+++ b/app/views/round/_matchup_summary_entry.html.erb
@@ -1,11 +1,12 @@
 <% count = @matchup_data[matchup.id][outcome] || 0 %>
+<% total = @matchup_data[matchup.id][:total] %>
 <% winner, num_games, possible = matchup.outcome_by_index(outcome) %>
 <% bg = "bg-danger bg-gradient text-white text-decoration-line-through" unless possible %>
 <% bg = "bg-success bg-gradient text-white" if possible && matchup.finished? %>
 <td class="text-end text-nowrap <%= bg %>"><%= winner.name %> in <%= num_games %></td>
 <td class="align-middle" style="min-width: 75px;">
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15" data-bs-toggle="tooltip" data-bs-html="true" title="<%= "#{count} #{"person".pluralize(count)} picked #{winner.name} in #{num_games}." %>">
-    <% pct = (count.to_f * 100 / @num_users).round(4) %>
+    <% pct = (count.to_f * 100 / total).round(4) %>
     <div class="progress-bar bg-secondary" role="progressbar" style="width: <%= pct %>%">
       <%= count %>
     </div>


### PR DESCRIPTION
When I turned these summary counts into progress bars, there was a known deficiency in that it used the total number of users on the page, rather than the number of picks for the matchup. These numbers are different when some users missed making picks.

I just discovered it's an easy fix.