### PR TITLE
Add rounds tabs to standings for admins only

### DIFF
--- a/app/controllers/round_controller.rb
+++ b/app/controllers/round_controller.rb
@@ -14,17 +14,11 @@ class RoundController < ApplicationController
 
     picks = Pick.joins(:matchup).merge(matchups).includes(:matchup, :user)
 
-    @matchups = picks.map(&:matchup)
+    matchups = picks.map(&:matchup)
       .uniq
       .sort
-    @show_totals = @matchups.length > 1
 
-    @round_name = @matchups.first.round_name
-    @num_outcomes = @matchups.first.games_needed_to_win * 2
-
-    @user_data = UserScores::Round.build(picks)
-
-    @num_users = @user_data.length
+    user_data = UserScores::Round.build(picks)
 
     # For each matchup, count the picks for each outcome
     @matchup_data = picks.group_by(&:matchup_id)
@@ -33,6 +27,14 @@ class RoundController < ApplicationController
         .transform_values(&:length)
         .merge(total: pps.length)
     end
+
+    @round_data = {
+      number: params[:round].to_i,
+      matchups: matchups,
+      user_data: user_data,
+      show_totals: matchups.length > 1,
+      num_outcomes: matchups.first.games_needed_to_win * 2
+    }
 
     @bg_color = BG_COLORS[params[:round].to_i]
   end

--- a/app/controllers/round_controller.rb
+++ b/app/controllers/round_controller.rb
@@ -28,14 +28,15 @@ class RoundController < ApplicationController
         .merge(total: pps.length)
     end
 
+    round_number = params[:round].to_i
+
     @round_data = {
-      number: params[:round].to_i,
+      number: round_number,
       matchups: matchups,
       user_data: user_data,
       show_totals: matchups.length > 1,
-      num_outcomes: matchups.first.games_needed_to_win * 2
+      num_outcomes: matchups.first.games_needed_to_win * 2,
+      bg_color: BG_COLORS[round_number]
     }
-
-    @bg_color = BG_COLORS[params[:round].to_i]
   end
 end

--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -14,5 +14,36 @@ class StandingsController < ApplicationController
     @rounds = @data.flat_map { |t| t.rounds.keys }.uniq.sort
 
     @bg_colors = BG_COLORS
+
+    @rounds_data = @rounds.map do |n|
+      build_round_data(n, picks)
+    end
+
+    # For each matchup, count the picks for each outcome
+    @matchup_data = picks.group_by(&:matchup_id)
+      .transform_values do |pps|
+      pps.group_by(&:scoring_index)
+        .transform_values(&:length)
+        .merge(total: pps.length)
+    end
+
+    @show_new_rounds_interface = Rails.env.development? || current_user&.admin?
+  end
+
+  def build_round_data(n, picks)
+    picks = picks.select { |pick| pick.matchup.round == n }
+    matchups = picks.map(&:matchup).uniq.sort
+    # TODO: Improve UserScores::Total to replace this and
+    # remove the redundancy.
+    user_data = UserScores::Round.build(picks)
+
+    {
+      number: n,
+      matchups: matchups,
+      user_data: user_data,
+      show_totals: matchups.length > 1,
+      num_outcomes: matchups.first.games_needed_to_win * 2,
+      bg_color: BG_COLORS[n]
+    }
   end
 end

--- a/app/lib/user_scores/round.rb
+++ b/app/lib/user_scores/round.rb
@@ -4,7 +4,7 @@ module UserScores
     attr_accessor :max_possible_round_total, :biggest_matchup_max_possible
 
     def self.build(picks)
-      scores = super(picks)
+      scores = super
 
       max_possibles = picks.map(&:matchup).uniq.map(&:max_possible_points)
       biggest_matchup_max_possible = max_possibles.max
@@ -16,7 +16,7 @@ module UserScores
     end
 
     def initialize(user, picks)
-      super(user, picks)
+      super
       @picks_by_matchup_id = picks.index_by(&:matchup_id)
     end
 

--- a/app/lib/user_scores/total.rb
+++ b/app/lib/user_scores/total.rb
@@ -3,7 +3,7 @@ module UserScores
     attr_reader :rounds
 
     def initialize(user, picks)
-      super(user, picks)
+      super
 
       @rounds = picks.select { |p| p.matchup.started? }
         .group_by { |p| p.matchup.round }

--- a/app/views/round/_matchup_summary_row.html.erb
+++ b/app/views/round/_matchup_summary_row.html.erb
@@ -1,9 +1,9 @@
 <tr>
 <td></td>
 <td></td>
-<% if @round_data[:show_totals] %>
+<% if round_data[:show_totals] %>
   <td></td>
   <%= render partial: 'shared/empty_cell' %>
 <% end %>
-<%= render partial: 'round/matchup_summary_entry', collection: @round_data[:matchups], as: :matchup, locals: {outcome: outcome}, spacer_template: 'shared/empty_cell' %>
+<%= render partial: 'round/matchup_summary_entry', collection: round_data[:matchups], as: :matchup, locals: {outcome: outcome}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/_matchup_summary_row.html.erb
+++ b/app/views/round/_matchup_summary_row.html.erb
@@ -1,9 +1,9 @@
 <tr>
 <td></td>
 <td></td>
-<% if @show_totals %>
+<% if @round_data[:show_totals] %>
   <td></td>
   <%= render partial: 'shared/empty_cell' %>
 <% end %>
-<%= render partial: 'round/matchup_summary_entry', collection: @matchups, as: :matchup, locals: {outcome: outcome}, spacer_template: 'shared/empty_cell' %>
+<%= render partial: 'round/matchup_summary_entry', collection: @round_data[:matchups], as: :matchup, locals: {outcome: outcome}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -8,13 +8,13 @@
     <div class="progress bg-secondary" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
       <% if pick.min_points.positive? %>
         <% pct = (pick.min_points_percentage * 100).round(4) %>
-        <div class="progress-bar <%= @bg_color %>" role="progressbar" style="width: <%= pct %>%">
+        <div class="progress-bar <%= round_data[:bg_color] %>" role="progressbar" style="width: <%= pct %>%">
           <%= pick.min_points %>
         </div>
       <% end %>
       <% if pick.potential_points.positive? %>
         <% pct = (pick.potential_points_percentage * 100).round(4) %>
-        <div class="progress-bar progress-bar-striped <%= @bg_color %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
+        <div class="progress-bar progress-bar-striped <%= round_data[:bg_color] %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
           <%= pick.potential_points %>
         </div>
       <% end %>

--- a/app/views/round/_round_table.html.erb
+++ b/app/views/round/_round_table.html.erb
@@ -4,18 +4,18 @@
       <tr>
         <th scope="col">#</th>
         <th scope="col">Name</th>
-        <% if @round_data[:show_totals] %>
+        <% if round_data[:show_totals] %>
           <th scope="col" class="text-center">Total</th>
           <%= render partial: 'shared/empty_cell' %>
         <% end %>
-        <%= render partial: 'round/matchup_title', collection: @round_data[:matchups], as: :matchup, spacer_template: 'shared/empty_cell' %>
+        <%= render partial: 'round/matchup_title', collection: round_data[:matchups], as: :matchup, spacer_template: 'shared/empty_cell' %>
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'round/user_row', collection: @round_data[:user_data], as: :user_round %>
+      <%= render partial: 'round/user_row', collection: round_data[:user_data], as: :user_round, locals: {round_data: round_data} %>
     </tbody>
     <tfoot>
-      <%= render partial: 'round/matchup_summary_row', collection: (0...@round_data[:num_outcomes]).to_a, as: :outcome %>
+      <%= render partial: 'round/matchup_summary_row', collection: (0...round_data[:num_outcomes]).to_a, as: :outcome, locals: {round_data: round_data} %>
     </tfoot>
   </table>
 </div>

--- a/app/views/round/_round_table.html.erb
+++ b/app/views/round/_round_table.html.erb
@@ -1,0 +1,21 @@
+<div class="table-responsive">
+  <table class="table table-hover table-sm">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Name</th>
+        <% if @round_data[:show_totals] %>
+          <th scope="col" class="text-center">Total</th>
+          <%= render partial: 'shared/empty_cell' %>
+        <% end %>
+        <%= render partial: 'round/matchup_title', collection: @round_data[:matchups], as: :matchup, spacer_template: 'shared/empty_cell' %>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'round/user_row', collection: @round_data[:user_data], as: :user_round %>
+    </tbody>
+    <tfoot>
+      <%= render partial: 'round/matchup_summary_row', collection: (0...@round_data[:num_outcomes]).to_a, as: :outcome %>
+    </tfoot>
+  </table>
+</div>

--- a/app/views/round/_total_cell.html.erb
+++ b/app/views/round/_total_cell.html.erb
@@ -2,13 +2,13 @@
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15;" data-bs-toggle="tooltip" data-bs-html="true" title="<%= user_round.points_tooltip %>">
     <% if user_round.min_total.positive? %>
       <% pct = (user_round.min_total_percentage * 100).round(4) %>
-      <div class="progress-bar <%= @bg_color %>" role="progressbar" style="width: <%= pct %>%">
+      <div class="progress-bar <%= round_data[:bg_color] %>" role="progressbar" style="width: <%= pct %>%">
         <%= user_round.min_total %>
       </div>
     <% end %>
     <% if user_round.potential_total.positive? %>
       <% pct = (user_round.potential_total_percentage * 100).round(4) %>
-      <div class="progress-bar progress-bar-striped <%= @bg_color %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
+      <div class="progress-bar progress-bar-striped <%= round_data[:bg_color] %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
         <%= user_round.potential_total %>
       </div>
     <% end %>

--- a/app/views/round/_user_row.html.erb
+++ b/app/views/round/_user_row.html.erb
@@ -1,9 +1,9 @@
 <tr <%= "class=fw-bold" if user_round.user == current_user %>>
   <td style="width: 1%;"><%= user_round.rank %></td>
   <%= render partial: 'shared/user_cell', locals: {user: user_round.user} %>
-  <% if @round_data[:show_totals] %>
+  <% if round_data[:show_totals] %>
     <%= render partial: 'round/total_cell', locals: {user_round: user_round} %>
     <%= render partial: 'shared/empty_cell' %>
   <% end %>
-  <%= render partial: 'round/pick_cell', collection: @round_data[:matchups], as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
+  <%= render partial: 'round/pick_cell', collection: round_data[:matchups], as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/_user_row.html.erb
+++ b/app/views/round/_user_row.html.erb
@@ -1,9 +1,9 @@
 <tr <%= "class=fw-bold" if user_round.user == current_user %>>
   <td style="width: 1%;"><%= user_round.rank %></td>
   <%= render partial: 'shared/user_cell', locals: {user: user_round.user} %>
-  <% if @show_totals %>
+  <% if @round_data[:show_totals] %>
     <%= render partial: 'round/total_cell', locals: {user_round: user_round} %>
     <%= render partial: 'shared/empty_cell' %>
   <% end %>
-  <%= render partial: 'round/pick_cell', collection: @matchups, as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
+  <%= render partial: 'round/pick_cell', collection: @round_data[:matchups], as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/_user_row.html.erb
+++ b/app/views/round/_user_row.html.erb
@@ -2,8 +2,8 @@
   <td style="width: 1%;"><%= user_round.rank %></td>
   <%= render partial: 'shared/user_cell', locals: {user: user_round.user} %>
   <% if round_data[:show_totals] %>
-    <%= render partial: 'round/total_cell', locals: {user_round: user_round} %>
+    <%= render partial: 'round/total_cell', locals: {user_round: user_round, round_data: round_data} %>
     <%= render partial: 'shared/empty_cell' %>
   <% end %>
-  <%= render partial: 'round/pick_cell', collection: round_data[:matchups], as: :matchup, locals: {user_round: user_round}, spacer_template: 'shared/empty_cell' %>
+  <%= render partial: 'round/pick_cell', collection: round_data[:matchups], as: :matchup, locals: {user_round: user_round, round_data: round_data}, spacer_template: 'shared/empty_cell' %>
 </tr>

--- a/app/views/round/show.html.erb
+++ b/app/views/round/show.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-pills mb-3">
   <% @round_names.sort.each do |n, name| %>
-    <% current = n.to_s == params[:round] %>
+    <% current = n == @round_data[:number] %>
     <li class="nav-item">
       <% if current %>
         <button class="nav-link active"><%= name %></button>
@@ -17,18 +17,18 @@
       <tr>
         <th scope="col">#</th>
         <th scope="col">Name</th>
-        <% if @show_totals %>
+        <% if @round_data[:show_totals] %>
           <th scope="col" class="text-center">Total</th>
           <%= render partial: 'shared/empty_cell' %>
         <% end %>
-        <%= render partial: 'round/matchup_title', collection: @matchups, as: :matchup, spacer_template: 'shared/empty_cell' %>
+        <%= render partial: 'round/matchup_title', collection: @round_data[:matchups], as: :matchup, spacer_template: 'shared/empty_cell' %>
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'round/user_row', collection: @user_data, as: :user_round %>
+      <%= render partial: 'round/user_row', collection: @round_data[:user_data], as: :user_round %>
     </tbody>
     <tfoot>
-      <%= render partial: 'round/matchup_summary_row', collection: (0...@num_outcomes).to_a, as: :outcome %>
+      <%= render partial: 'round/matchup_summary_row', collection: (0...@round_data[:num_outcomes]).to_a, as: :outcome %>
     </tfoot>
   </table>
 </div>

--- a/app/views/round/show.html.erb
+++ b/app/views/round/show.html.erb
@@ -11,24 +11,4 @@
   <% end %>
 </ul>
 
-<div class="table-responsive">
-  <table class="table table-hover table-sm">
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Name</th>
-        <% if @round_data[:show_totals] %>
-          <th scope="col" class="text-center">Total</th>
-          <%= render partial: 'shared/empty_cell' %>
-        <% end %>
-        <%= render partial: 'round/matchup_title', collection: @round_data[:matchups], as: :matchup, spacer_template: 'shared/empty_cell' %>
-      </tr>
-    </thead>
-    <tbody>
-      <%= render partial: 'round/user_row', collection: @round_data[:user_data], as: :user_round %>
-    </tbody>
-    <tfoot>
-      <%= render partial: 'round/matchup_summary_row', collection: (0...@round_data[:num_outcomes]).to_a, as: :outcome %>
-    </tfoot>
-  </table>
-</div>
+<%= render partial: 'round/round_table' %>

--- a/app/views/round/show.html.erb
+++ b/app/views/round/show.html.erb
@@ -11,4 +11,4 @@
   <% end %>
 </ul>
 
-<%= render partial: 'round/round_table' %>
+<%= render partial: 'round/round_table', locals: {round_data: @round_data} %>

--- a/app/views/standings/index.html.erb
+++ b/app/views/standings/index.html.erb
@@ -1,10 +1,13 @@
-<ul class="nav nav-pills" id="standingsTabs" role="tablist">
+<ul class="nav nav-pills mb-3" id="standingsTabs" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link active" id="chart-tab" data-bs-toggle="tab" data-bs-target="#chart" type="button" role="tab" aria-controls="chart" aria-selected="true">Chart</button>
   </li>
   <li class="nav-item" role="presentation">
     <button class="nav-link" id="table-tab" data-bs-toggle="tab" data-bs-target="#table" type="button" role="tab" aria-controls="table" aria-selected="false">Table</button>
   </li>
+  <% if @show_new_rounds_interface %>
+    <%= render partial: 'standings/nav/round_list_item', collection: @rounds_data, as: :round_data %>
+  <% end %>
 </ul>
 <div class="tab-content" id="standingsTabsContent">
   <div class="tab-pane fade show active" id="chart" role="tabpanel" aria-labelledby="chart-tab">
@@ -13,6 +16,9 @@
   <div class="tab-pane fade" id="table" role="tabpanel" aria-labelledby="table-tab">
     <%= render partial: 'standings/numbers_table' %>
   </div>
+  <% if @show_new_rounds_interface %>
+    <%= render partial: 'standings/nav/round_tab_pane', collection: @rounds_data, as: :round_data %>
+  <% end %>
 </div>
 
 

--- a/app/views/standings/nav/_round_list_item.html.erb
+++ b/app/views/standings/nav/_round_list_item.html.erb
@@ -1,0 +1,4 @@
+<% n = round_data[:number] %>
+<li class="nav-item" role="presentation">
+  <button class="nav-link" id="round-<%= n %>-tab" data-bs-toggle="tab" data-bs-target="#round-<%= n %>-table" type="button" role="tab" aria-controls="round-<%= n %>-table" aria-selected="false"><%= @round_names[n] %></button>
+</li>

--- a/app/views/standings/nav/_round_tab_pane.html.erb
+++ b/app/views/standings/nav/_round_tab_pane.html.erb
@@ -1,0 +1,4 @@
+<% n = round_data[:number] %>
+<div class="tab-pane fade" id="round-<%= n %>-table" role="tabpanel" aria-labelledby="round-<%= n %>-table-tab">
+  <%= render partial: 'round/round_table', locals: {round_data: round_data} %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   root to: redirect(CurrentSeason.path)
   resources :picks, only: %i[index new create]
+  # TODO: Add constraint on :sport values
   get "/:sport/:year", to: "standings#index"
   get "/:sport/:year/:round", to: "round#show"
 end


### PR DESCRIPTION
In a step towards overhauling the nav, and being able to sort round tables by overall score, etc., this adds tabs to the Standings page for all the individual rounds, **for admins only right now**.

These tabs should look identical to the pages under Pool Picks.

The next step after this PR will be:
- Figure out how to make the Chart/Table tabs work together with these
- Reveal these new tabs to all users
- Eliminate Pool Picks from the top nav and eliminate the old round pages
- Redirect old round routes to the standings route for the sport/year
- Simplify the Past Seasons nav, since it no longer needs separate entries for Standings and Picks