### PR TITLE
Use propr NBA round names instead of numbers

### DIFF
--- a/app/lib/playoff_structure.rb
+++ b/app/lib/playoff_structure.rb
@@ -42,17 +42,17 @@ module PlayoffStructure
 
   NBA = [
     {
-      name: "Round 1",
+      name: "First Round",
       games_needed_to_win: 4,
       matchups_per_conference: 4
     },
     {
-      name: "Round 2",
+      name: "Conf. Semifinals",
       games_needed_to_win: 4,
       matchups_per_conference: 2
     },
     {
-      name: "Round 3",
+      name: "Conf. Finals",
       games_needed_to_win: 4,
       matchups_per_conference: 1
     },

--- a/app/lib/playoff_structure.rb
+++ b/app/lib/playoff_structure.rb
@@ -47,12 +47,12 @@ module PlayoffStructure
       matchups_per_conference: 4
     },
     {
-      name: "Conf. Semifinals",
+      name: "Conf Semis",
       games_needed_to_win: 4,
       matchups_per_conference: 2
     },
     {
-      name: "Conf. Finals",
+      name: "Conf Finals",
       games_needed_to_win: 4,
       matchups_per_conference: 1
     },


### PR DESCRIPTION
Similar to what we have for MLB, I think the real names look nicer than just "Round X." I abbreviated "conference" though for the sake of width on mobile.

![desktop](https://github.com/jmanian/nba-playoff-pool/assets/6848109/b51c8f9d-3c54-430d-a8ae-91b7c12cdfb0)

![mobile](https://github.com/jmanian/nba-playoff-pool/assets/6848109/582bc63d-6a8b-4e10-8cec-41dc17e69cf6)
