### PR TITLE
Fix sync for series with a team missing

### DIFF
--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -137,11 +137,11 @@ module Sync
       end
 
       def favorite_tricode
-        series_data[:highSeedTricode]&.downcase
+        series_data[:highSeedTricode].presence&.downcase
       end
 
       def underdog_tricode
-        series_data[:lowSeedTricode]&.downcase
+        series_data[:lowSeedTricode].presence&.downcase
       end
 
       def favorite_wins

--- a/spec/lib/sync/nba/matchups_spec.rb
+++ b/spec/lib/sync/nba/matchups_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe Sync::Nba::Matchups do
     end
 
     shared_examples_for "syncing" do
+      context "when both teams are unknown" do
+        pending "test with all data as null"
+      end
+
+      context "when one team is unknown" do
+        pending "test with the unknown team as blank strings"
+      end
+
       context "when the series hasn't started yet" do
         let(:favorite_wins) { 0 }
         let(:underdog_wins) { 0 }


### PR DESCRIPTION
When one team is known and the other unknown the tricode comes in as a blank string, whereas when both teams are unknown they both come as null. So this was leading to it trying to create an invalid matchup, with a blank team. Luckily the invalid ones have been last in the data so the others process first.