### PR TITLE
Add nicknames for teams with long names

### DIFF
--- a/app/lib/team.rb
+++ b/app/lib/team.rb
@@ -1,14 +1,19 @@
 class Team
-  attr_reader :tricode, :city, :name
+  attr_reader :tricode, :city, :name, :nickname
 
-  def initialize(tricode, city, name)
+  def initialize(tricode, city, name, nickname)
     @tricode = tricode
     @city = city
     @name = name
+    @nickname = nickname
   end
 
   def full_name
     [city, name].join(" ")
+  end
+
+  def short_name
+    nickname || name
   end
 
   NBA_TEAMS = [
@@ -17,8 +22,8 @@ class Team
     [:bos, "Boston", "Celtics"],
     [:cha, "Charlotte", "Hornets"],
     [:chi, "Chicago", "Bulls"],
-    [:cle, "Cleveland", "Cavaliers"],
-    [:dal, "Dallas", "Mavericks"],
+    [:cle, "Cleveland", "Cavaliers", "Cavs"],
+    [:dal, "Dallas", "Mavericks", "Mavs"],
     [:den, "Denver", "Nuggets"],
     [:det, "Detroit", "Pistons"],
     [:gsw, "Golden State", "Warriors"],
@@ -29,21 +34,21 @@ class Team
     [:mem, "Memphis", "Grizzlies"],
     [:mia, "Miami", "Heat"],
     [:mil, "Milwaukee", "Bucks"],
-    [:min, "Minnesota", "Timberwolves"],
+    [:min, "Minnesota", "Timberwolves", "T'wolves"],
     [:nop, "New Orleans", "Pelicans"],
     [:nyk, "New York", "Knicks"],
     [:okc, "Oklahoma City", "Thunder"],
     [:orl, "Orlando", "Magic"],
     [:phi, "Philadelphia", "76ers"],
     [:phx, "Phoenix", "Suns"],
-    [:por, "Portland", "Trail Blazers"],
+    [:por, "Portland", "Trail Blazers", "Blazers"],
     [:sac, "Sacramento", "Kings"],
     [:sas, "San Antonio", "Spurs"],
     [:tor, "Toronto", "Raptors"],
     [:uta, "Utah", "Jazz"],
     [:was, "Washington", "Wizards"]
-  ].map { |tc, c, n| [tc, Team.new(tc, c, n)] }
-    .to_h.with_indifferent_access
+  ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
+    .with_indifferent_access
 
   MLB_TEAMS = [
     [:ari, "Arizona", "Diamondbacks"],
@@ -76,7 +81,7 @@ class Team
     [:tex, "Texas", "Rangers"],
     [:tor, "Toronto", "Blue Jays"],
     [:wsh, "Washington", "Nationals"]
-  ].to_h { |tc, c, n| [tc, Team.new(tc, c, n)] }
+  ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
     .with_indifferent_access
 
   class << self

--- a/app/models/matchup.rb
+++ b/app/models/matchup.rb
@@ -123,11 +123,11 @@ class Matchup < ApplicationRecord
   end
 
   def favorite_name_and_wins
-    "#{favorite.name} (#{favorite_wins})"
+    "#{favorite.short_name} (#{favorite_wins})"
   end
 
   def underdog_name_and_wins
-    "#{underdog.name} (#{underdog_wins})"
+    "#{underdog.short_name} (#{underdog_wins})"
   end
 
   # The overall structure of the playoffs for the sport and year

--- a/spec/lib/team_spec.rb
+++ b/spec/lib/team_spec.rb
@@ -7,6 +7,20 @@ describe Team do
     it { should be_present }
   end
 
+  describe "#short_name" do
+    subject { team.short_name }
+
+    context "when the team has a nickname" do
+      let(:team) { described_class.nba(:cle) }
+      it { should eql "Cavs" }
+    end
+
+    context "when the team does not have a nickname" do
+      let(:team) { described_class.nba(:atl) }
+      it { should eql "Hawks" }
+    end
+  end
+
   describe "::NBA_TEAMS" do
     subject { described_class::NBA_TEAMS }
 


### PR DESCRIPTION
The nicknames are used on the table headings but not elsewhere. Resolves #134.