### PR TITLE
Automatically sync MLB matchups

### DIFF
--- a/app/lib/sync/matchup_base.rb
+++ b/app/lib/sync/matchup_base.rb
@@ -1,0 +1,87 @@
+module Sync
+  class MatchupBase
+    def sync_matchup
+      if series_started?
+        sync_wins
+      elsif existing_matchup
+        sync_starts_at
+      elsif teams_known?
+        create_matchup
+      end
+    end
+
+    private
+
+    attr_reader :year, :series_data
+
+    def sync_wins
+      matchup = existing_matchup
+
+      if matchup
+        matchup.favorite_wins = favorite_wins
+        matchup.underdog_wins = underdog_wins
+        matchup.save! if matchup.has_changes_to_save?
+
+        log_update(matchup)
+      end
+    end
+
+    def sync_starts_at
+      matchup = existing_matchup
+
+      if !matchup.started? && starts_at
+        matchup.update!(starts_at: starts_at)
+      end
+
+      log_update(matchup)
+    end
+
+    def log_update(matchup)
+      return unless matchup
+
+      data = {id: matchup.id, changes: matchup.saved_changes.except(:updated_at)}
+      Rails.logger.info("Matchup updated: #{data.to_json}")
+    end
+
+    def create_matchup
+      return if existing_matchup || find_existing_reversed_matchup
+
+      matchup = Matchup.create!(
+        sport: sport,
+        year: year,
+        round: round,
+        conference: conference,
+        number: number,
+        favorite_tricode: favorite_tricode,
+        underdog_tricode: underdog_tricode,
+        favorite_wins: favorite_wins,
+        underdog_wins: underdog_wins,
+        starts_at: starts_at
+      )
+
+      Rails.logger.info("Matchup created: #{matchup.attributes.except("created_at", "updated_at").to_json}")
+    end
+
+    def existing_matchup
+      @existing_matchup ||=
+        matchup_base.find_by(favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode)
+    end
+
+    # Just to be extra careful, this looks for a matchup where the teams are reversed.
+    def find_existing_reversed_matchup
+      matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
+    end
+
+    def matchup_base
+      Matchup.where(sport: sport, year: year, round: round, conference: conference)
+    end
+
+    def series_started?
+      favorite_wins > 0 || underdog_wins > 0
+    end
+
+    def teams_known?
+      favorite_tricode && underdog_tricode
+    end
+  end
+end

--- a/app/lib/sync/mlb/client.rb
+++ b/app/lib/sync/mlb/client.rb
@@ -1,0 +1,36 @@
+module Sync
+  module Mlb
+    class Client
+      POSTSEASON_URL = "https://statsapi.mlb.com/api/v1/schedule/postseason/series?season=%{year}".freeze
+      TEAMS_URL = "https://statsapi.mlb.com/api/v1/teams?sportId=1".freeze
+
+      def self.fetch_postseason(year)
+        new.fetch_postseason(year)
+      end
+
+      def self.fetch_teams
+        new.fetch_teams
+      end
+
+      def fetch_postseason(year)
+        url = POSTSEASON_URL % {year: year}
+        fetch_from_url(url)
+      end
+
+      def fetch_teams
+        url = TEAMS_URL
+        fetch_from_url(url)
+      end
+
+      private
+
+      def fetch_from_url(url)
+        connection = Faraday.new(url: url) do |f|
+          f.response :json, parser_options: {symbolize_names: true}
+          f.response :raise_error
+        end
+        connection.get.body
+      end
+    end
+  end
+end

--- a/app/lib/sync/mlb/matchups.rb
+++ b/app/lib/sync/mlb/matchups.rb
@@ -1,0 +1,110 @@
+module Sync
+  module Mlb
+    class Matchups < MatchupBase
+      def self.run(year)
+        team_data = Client.fetch_teams[:teams]
+        team_ids_to_abbreviations = team_data.to_h { |t| [t[:id], t[:abbreviation].downcase] }
+
+        all_series = Client.fetch_postseason(year)
+        all_series[:series].each do |series_data|
+          sync_matchup(year, series_data, team_ids_to_abbreviations)
+        end
+      end
+
+      def self.sync_matchup(year, series_data, team_ids_to_abbreviations)
+        new(year, series_data, team_ids_to_abbreviations).sync_matchup
+      end
+
+      def initialize(year, series_data, team_ids_to_abbreviations)
+        @year = year
+        @series_data = series_data
+        @team_ids_to_abbreviations = team_ids_to_abbreviations
+      end
+
+      attr_reader :team_ids_to_abbreviations
+
+      def sport
+        :mlb
+      end
+
+      def round
+        case series_data[:series][:gameType]
+        when "F"
+          1
+        when "D"
+          2
+        when "L"
+          3
+        when "W"
+          4
+        end
+      end
+
+      def conference
+        return "ws" if series_data[:series][:gameType] == "W"
+
+        case series_data[:games].first[:description]
+        when /AL/
+          "al"
+        when /NL/
+          "nl"
+        end
+      end
+
+      def number
+        # the id looks like F_2 or W_1, etc.
+        raw_number = series_data[:series][:id].split("_").last.to_i
+
+        # Series are numered consecutively within the round, starting at 1, and the AL
+        # series come first.
+        if conference == "nl"
+          raw_number - PlayoffStructure::MLB_V2[round - 1][:matchups_per_conference]
+        else
+          raw_number
+        end
+      end
+
+      def favorite_team_id
+        series_data[:games].first[:teams][:home][:team][:id]
+      end
+
+      def favorite_tricode
+        translate_team_abbreviation(team_ids_to_abbreviations[favorite_team_id])
+      end
+
+      def underdog_team_id
+        series_data[:games].first[:teams][:away][:team][:id]
+      end
+
+      def underdog_tricode
+        translate_team_abbreviation(team_ids_to_abbreviations[underdog_team_id])
+      end
+
+      def favorite_wins
+        series_data[:games].last[:teams].values.find { |t| t[:team][:id] == favorite_team_id }[:leagueRecord][:wins]
+      end
+
+      def underdog_wins
+        series_data[:games].last[:teams].values.find { |t| t[:team][:id] == underdog_team_id }[:leagueRecord][:wins]
+      end
+
+      # Translate API team abbreviations that differ from Team::MLB_TEAMS
+      def translate_team_abbreviation(abbreviation)
+        case abbreviation
+        when "ath"
+          "oak"
+        when "az"
+          "ari"
+        else
+          abbreviation
+        end
+      end
+
+      def starts_at
+        if series_data[:games].first[:gameDate].present?
+          Time.parse(series_data[:games].first[:gameDate])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -1,6 +1,6 @@
 module Sync
   module Nba
-    class Matchups
+    class Matchups < MatchupBase
       def self.run(year)
         bracket = Client.fetch_bracket(year)[:bracket]
         all_series = bracket[:playoffBracketSeries]
@@ -21,89 +21,7 @@ module Sync
         @series_data = series_data
       end
 
-      def sync_matchup
-        if series_started?
-          sync_wins
-        elsif existing_matchup
-          sync_starts_at
-        elsif teams_known?
-          create_matchup
-        end
-      end
-
       private
-
-      attr_reader :year, :series_data
-
-      def sync_wins
-        matchup = existing_matchup
-
-        if matchup
-          matchup.favorite_wins = favorite_wins
-          matchup.underdog_wins = underdog_wins
-          matchup.save! if matchup.has_changes_to_save?
-
-          log_update(matchup)
-        end
-      end
-
-      def sync_starts_at
-        matchup = existing_matchup
-
-        if !matchup.started? && starts_at
-          matchup.update!(starts_at: starts_at)
-        end
-
-        log_update(matchup)
-      end
-
-      def log_update(matchup)
-        return unless matchup
-
-        data = {id: matchup.id, changes: matchup.saved_changes.except(:updated_at)}
-        Rails.logger.info("Matchup updated: #{data.to_json}")
-      end
-
-      def create_matchup
-        return if existing_matchup || find_existing_reversed_matchup
-
-        matchup = Matchup.create!(
-          sport: sport,
-          year: year,
-          round: round,
-          conference: conference,
-          number: number,
-          favorite_tricode: favorite_tricode,
-          underdog_tricode: underdog_tricode,
-          favorite_wins: favorite_wins,
-          underdog_wins: underdog_wins,
-          starts_at: starts_at
-        )
-
-        Rails.logger.info("Matchup created: #{matchup.attributes.except("created_at", "updated_at").to_json}")
-      end
-
-      def existing_matchup
-        @existing_matchup ||=
-          matchup_base.find_by(favorite_tricode: favorite_tricode, underdog_tricode: underdog_tricode)
-      end
-
-      # Just to be extra careful, this looks for a matchup where the teams are reversed.
-      def find_existing_reversed_matchup
-        matchup_base.find_by(favorite_tricode: underdog_tricode, underdog_tricode: favorite_tricode)
-      end
-
-      def matchup_base
-        Matchup.where(sport: sport, year: year, round: round, conference: conference)
-      end
-
-      def series_started?
-        favorite_wins > 0 || underdog_wins > 0
-      end
-
-      def teams_known?
-        favorite_tricode && underdog_tricode
-      end
 
       def sport
         :nba

--- a/app/lib/sync/nba/matchups.rb
+++ b/app/lib/sync/nba/matchups.rb
@@ -68,7 +68,7 @@ module Sync
         return if existing_matchup || find_existing_reversed_matchup
 
         matchup = Matchup.create!(
-          sport: :nba,
+          sport: sport,
           year: year,
           round: round,
           conference: conference,
@@ -94,7 +94,7 @@ module Sync
       end
 
       def matchup_base
-        Matchup.where(sport: :nba, year: year, round: round, conference: conference)
+        Matchup.where(sport: sport, year: year, round: round, conference: conference)
       end
 
       def series_started?
@@ -103,6 +103,10 @@ module Sync
 
       def teams_known?
         favorite_tricode && underdog_tricode
+      end
+
+      def sport
+        :nba
       end
 
       def round

--- a/lib/tasks/sync_matchups.rake
+++ b/lib/tasks/sync_matchups.rake
@@ -1,6 +1,9 @@
 desc "Sync Matchups from the league API, NBA only for now"
 task sync_matchups: :environment do
-  if CurrentSeason.sport == :nba
+  case CurrentSeason.sport
+  when :nba
     Sync::Nba::Matchups.run(CurrentSeason.year)
+  when :mlb
+    Sync::Mlb::Matchups.run(CurrentSeason.year)
   end
 end

--- a/spec/cassettes/Sync_Mlb_Client/_fetch_postseason/for_the_2023_playoffs/returns_the_JSON_from_the_2023_postseason_series_endpoint.yml
+++ b/spec/cassettes/Sync_Mlb_Client/_fetch_postseason/for_the_2023_playoffs/returns_the_JSON_from_the_2023_postseason_series_endpoint.yml
@@ -1,0 +1,308 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://statsapi.mlb.com/api/v1/schedule/postseason/series?season=2023
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.8.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '4653'
+      cache-control:
+      - max-age=20, public, stale-while-revalidate=30, stale-if-error=86400
+      expires:
+      - Fri, 26 Sep 2025 17:40:53 GMT
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      access-control-allow-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-expose-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      via:
+      - 1.1 google, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      age:
+      - '0'
+      date:
+      - Fri, 26 Sep 2025 17:40:33 GMT
+      x-served-by:
+      - cache-iad-kjyo7100115-IAD, cache-lga21939-LGA
+      x-cache:
+      - MISS, MISS
+      x-cache-hits:
+      - 0, 0
+      x-timer:
+      - S1758908434.857606,VS0,VE100
+      vary:
+      - accept-encoding, Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"copyright":"Copyright 2025 MLB Advanced Media, L.P.  Use of any content
+        on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt","totalItems":41,"totalEvents":0,"totalGames":41,"totalGamesInProgress":0,"wait":10,"series":[{"series":{"id":"W_1","sortNumber":1,"isDefault":true,"gameType":"W"},"totalItems":5,"totalGames":5,"totalGamesInProgress":0,"games":[{"gamePk":748542,"gameGuid":"2c02da53-e7c5-4017-8d9c-059c0506dc51","link":"/api/v1.1/game/748542/feed/live","gameType":"W","season":"2023","gameDate":"2023-10-28T00:05:00Z","officialDate":"2023-10-27","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":5,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748542/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748542-2023-10-27","seasonDisplay":"2023","dayNight":"night","description":"World
+        Series Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748541,"gameGuid":"95ce9e6a-bc4c-467f-bc0f-22d389358e92","link":"/api/v1.1/game/748541/feed/live","gameType":"W","season":"2023","gameDate":"2023-10-29T00:03:00Z","officialDate":"2023-10-28","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":9,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":1,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748541/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748541-2023-10-28","seasonDisplay":"2023","dayNight":"night","description":"World
+        Series Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748540,"gameGuid":"23481542-b0d7-4b8b-9d7f-044bfe95f8e6","link":"/api/v1.1/game/748540/feed/live","gameType":"W","season":"2023","gameDate":"2023-10-31T00:03:00Z","officialDate":"2023-10-30","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":3,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":1,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748540/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748540-2023-10-30","seasonDisplay":"2023","dayNight":"night","description":"World
+        Series Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748535,"gameGuid":"f6065a09-eed1-4e8e-a29f-52d6a6888754","link":"/api/v1.1/game/748535/feed/live","gameType":"W","season":"2023","gameDate":"2023-11-01T00:03:00Z","officialDate":"2023-10-31","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":11,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":7,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748535/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748535-2023-10-31","seasonDisplay":"2023","dayNight":"night","description":"World
+        Series Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748534,"gameGuid":"f3f76a5b-9530-4e02-99f1-40d4ce443e8c","link":"/api/v1.1/game/748534/feed/live","gameType":"W","season":"2023","gameDate":"2023-11-02T00:03:00Z","officialDate":"2023-11-01","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":4,"losses":1,"pct":".800"},"score":5,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":4,"pct":".200"},"score":0,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748534/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748534-2023-11-01","seasonDisplay":"2023","dayNight":"night","description":"World
+        Series Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":1},{"series":{"id":"F_2","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":748581,"gameGuid":"0bcbbf38-33ee-4322-8e0e-79a128c9185d","link":"/api/v1.1/game/748581/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-03T19:08:00Z","officialDate":"2023-10-03","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":4,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":139,"name":"Tampa
+        Bay Rays","link":"/api/v1/teams/139"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":12,"name":"Tropicana
+        Field","link":"/api/v1/venues/12"},"content":{"link":"/api/v1/game/748581/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748581-2023-10-03","seasonDisplay":"2023","dayNight":"day","description":"AL
+        Wild Card Series - 4 vs. 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748580,"gameGuid":"ce21176e-f207-4c96-8b56-9e8b21c6c485","link":"/api/v1.1/game/748580/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-04T19:08:00Z","officialDate":"2023-10-04","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":7,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":1,"team":{"id":139,"name":"Tampa
+        Bay Rays","link":"/api/v1/teams/139"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":12,"name":"Tropicana
+        Field","link":"/api/v1/venues/12"},"content":{"link":"/api/v1/game/748580/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748580-2023-10-04","seasonDisplay":"2023","dayNight":"day","description":"AL
+        Wild Card Series - 4 vs. 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_1","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":748585,"gameGuid":"35d70226-413a-48aa-bc22-60659bcebbd8","link":"/api/v1.1/game/748585/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-03T20:38:00Z","officialDate":"2023-10-03","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":1,"team":{"id":141,"name":"Toronto
+        Blue Jays","link":"/api/v1/teams/141"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":3,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3312,"name":"Target
+        Field","link":"/api/v1/venues/3312"},"content":{"link":"/api/v1/game/748585/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748585-2023-10-03","seasonDisplay":"2023","dayNight":"day","description":"AL
+        Wild Card Series - 3 vs.6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748583,"gameGuid":"02adbe27-88d1-4859-a9c5-12d1e4d18491","link":"/api/v1.1/game/748583/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-04T20:38:00Z","officialDate":"2023-10-04","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":0,"team":{"id":141,"name":"Toronto
+        Blue Jays","link":"/api/v1/teams/141"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":2,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3312,"name":"Target
+        Field","link":"/api/v1/venues/3312"},"content":{"link":"/api/v1/game/748583/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748583-2023-10-04","seasonDisplay":"2023","dayNight":"day","description":"AL
+        Wild Card Series - 3 vs.6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_4","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":748577,"gameGuid":"e7eaabe6-7f77-4005-ac75-8f17815b7895","link":"/api/v1.1/game/748577/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-04T00:08:00Z","officialDate":"2023-10-03","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":1,"team":{"id":146,"name":"Miami
+        Marlins","link":"/api/v1/teams/146"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":4,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748577/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748577-2023-10-03","seasonDisplay":"2023","dayNight":"night","description":"NL
+        Wild Card Series - 4 vs. 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748575,"gameGuid":"d1d05409-191d-4035-8312-4f2f30d301bc","link":"/api/v1.1/game/748575/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-05T00:08:00Z","officialDate":"2023-10-04","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":1,"team":{"id":146,"name":"Miami
+        Marlins","link":"/api/v1/teams/146"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":7,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748575/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748575-2023-10-04","seasonDisplay":"2023","dayNight":"night","description":"NL
+        Wild Card Series - 4 vs. 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_3","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":748582,"gameGuid":"cec69194-75f1-4fd6-bc20-cf0258cbb621","link":"/api/v1.1/game/748582/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-03T23:08:00Z","officialDate":"2023-10-03","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":3,"team":{"id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"content":{"link":"/api/v1/game/748582/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748582-2023-10-03","seasonDisplay":"2023","dayNight":"night","description":"NL
+        Wild Card Series - 3 vs.6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748578,"gameGuid":"4a5d80cf-4503-450d-9aba-0e21b7fa2ab4","link":"/api/v1.1/game/748578/feed/live","gameType":"F","season":"2023","gameDate":"2023-10-04T23:08:00Z","officialDate":"2023-10-04","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":5,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":2,"team":{"id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"content":{"link":"/api/v1/game/748578/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748578-2023-10-04","seasonDisplay":"2023","dayNight":"night","description":"NL
+        Wild Card Series - 3 vs.6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":145,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_2","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":4,"totalGames":4,"totalGamesInProgress":0,"games":[{"gamePk":748568,"gameGuid":"317742d9-8725-434a-820c-40aabedc0b41","link":"/api/v1.1/game/748568/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-07T20:45:00Z","officialDate":"2023-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":4,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748568/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748568-2023-10-07","seasonDisplay":"2023","dayNight":"day","description":"ALDS
+        ''B'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748565,"gameGuid":"b8fb580b-eab1-4ec4-9670-98ea8cbd2de9","link":"/api/v1.1/game/748565/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-09T00:03:00Z","officialDate":"2023-10-08","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":6,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":2,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748565/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748565-2023-10-08","seasonDisplay":"2023","dayNight":"night","description":"ALDS
+        ''B'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748567,"gameGuid":"a3dfb622-2142-4d53-8bc3-4f3c5b27af42","link":"/api/v1.1/game/748567/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-10T20:07:00Z","officialDate":"2023-10-10","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":9,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":1,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":3312,"name":"Target
+        Field","link":"/api/v1/venues/3312"},"content":{"link":"/api/v1/game/748567/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748567-2023-10-10","seasonDisplay":"2023","dayNight":"day","description":"ALDS
+        ''B'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748566,"gameGuid":"d0add9ab-6595-4a5d-b9f8-15ebe20f0291","link":"/api/v1.1/game/748566/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-11T23:07:00Z","officialDate":"2023-10-11","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":3,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":2,"team":{"id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":3312,"name":"Target
+        Field","link":"/api/v1/venues/3312"},"content":{"link":"/api/v1/game/748566/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748566-2023-10-11","seasonDisplay":"2023","dayNight":"night","description":"ALDS
+        ''B'' Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_1","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":3,"totalGames":3,"totalGamesInProgress":0,"games":[{"gamePk":748573,"gameGuid":"2cddaee5-3ec3-4329-968c-4ff04dd6049f","link":"/api/v1.1/game/748573/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-07T17:03:00Z","officialDate":"2023-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":3,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":2,"team":{"id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2,"name":"Oriole
+        Park at Camden Yards","link":"/api/v1/venues/2"},"content":{"link":"/api/v1/game/748573/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748573-2023-10-07","seasonDisplay":"2023","dayNight":"day","description":"ALDS
+        ''A'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748569,"gameGuid":"a05de737-601b-4fa4-9bc6-bcb76765c11b","link":"/api/v1.1/game/748569/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-08T20:07:00Z","officialDate":"2023-10-08","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":11,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":8,"team":{"id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2,"name":"Oriole
+        Park at Camden Yards","link":"/api/v1/venues/2"},"content":{"link":"/api/v1/game/748569/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748569-2023-10-08","seasonDisplay":"2023","dayNight":"day","description":"ALDS
+        ''A'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748572,"gameGuid":"e2332dfe-c255-43e1-a3b9-5d4feddb3de7","link":"/api/v1.1/game/748572/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-11T00:03:00Z","officialDate":"2023-10-10","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":3,"pct":".000"},"score":1,"team":{"id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":3,"losses":0,"pct":"1.000"},"score":7,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748572/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748572-2023-10-10","seasonDisplay":"2023","dayNight":"night","description":"ALDS
+        ''A'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_4","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":3,"totalGames":3,"totalGamesInProgress":0,"games":[{"gamePk":748555,"gameGuid":"c974c311-d0f6-4abf-84af-b072c80f2739","link":"/api/v1.1/game/748555/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-08T01:20:00Z","officialDate":"2023-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":11,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":2,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":4}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/748555/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748555-2023-10-07","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''B'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748556,"gameGuid":"b4db25b0-cb37-477c-855c-c0a0e921fa9b","link":"/api/v1.1/game/748556/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-10T01:07:00Z","officialDate":"2023-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":4,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":2,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":4}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/748556/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748556-2023-10-09","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''B'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748557,"gameGuid":"b2ce12fc-1735-415b-8287-32c5a1a7f5d5","link":"/api/v1.1/game/748557/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-12T01:07:00Z","officialDate":"2023-10-11","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":3,"pct":".000"},"score":2,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":3,"losses":0,"pct":"1.000"},"score":4,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748557/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748557-2023-10-11","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''B'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_3","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":4,"totalGames":4,"totalGamesInProgress":0,"games":[{"gamePk":748562,"gameGuid":"b0eae0f8-c51b-4cbc-a5f9-c94bf829f53d","link":"/api/v1.1/game/748562/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-07T22:07:00Z","officialDate":"2023-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":3,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":4705,"name":"Truist
+        Park","link":"/api/v1/venues/4705"},"content":{"link":"/api/v1/game/748562/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748562-2023-10-07","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''A'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748563,"gameGuid":"63540360-9712-4d8a-8b96-20bfb1515cb6","link":"/api/v1.1/game/748563/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-09T22:07:00Z","officialDate":"2023-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":4,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":5,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":4705,"name":"Truist
+        Park","link":"/api/v1/venues/4705"},"content":{"link":"/api/v1/game/748563/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748563-2023-10-09","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''A'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748564,"gameGuid":"27c70084-7e97-4be7-853a-14fbdaba46d2","link":"/api/v1.1/game/748564/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-11T21:07:00Z","officialDate":"2023-10-11","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":2,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":10,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748564/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748564-2023-10-11","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''A'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748561,"gameGuid":"c6bee97a-9d1f-4b5e-9950-e04513e0b36f","link":"/api/v1.1/game/748561/feed/live","gameType":"D","season":"2023","gameDate":"2023-10-13T00:07:00Z","officialDate":"2023-10-12","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":1,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":3,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748561/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748561-2023-10-12","seasonDisplay":"2023","dayNight":"night","description":"NLDS
+        ''A'' Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"L_1","sortNumber":0,"isDefault":false,"gameType":"L"},"totalItems":7,"totalGames":7,"totalGamesInProgress":0,"games":[{"gamePk":748553,"gameGuid":"26d4ba96-602c-4ea5-9563-d9de887f2d45","link":"/api/v1.1/game/748553/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-16T00:15:00Z","officialDate":"2023-10-15","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":2,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748553/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748553-2023-10-15","seasonDisplay":"2023","dayNight":"night","description":"ALCS
+        Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748548,"gameGuid":"1de9a00c-2f35-4e38-93c7-854ae6dcd96c","link":"/api/v1.1/game/748548/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-16T20:37:00Z","officialDate":"2023-10-16","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":5,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":4,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748548/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748548-2023-10-16","seasonDisplay":"2023","dayNight":"day","description":"ALCS
+        Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748552,"gameGuid":"cc641bd3-ec1c-49ba-a189-1e89c3ea0b62","link":"/api/v1.1/game/748552/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-19T00:03:00Z","officialDate":"2023-10-18","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":8,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":5,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748552/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748552-2023-10-18","seasonDisplay":"2023","dayNight":"night","description":"ALCS
+        Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748551,"gameGuid":"a288ca8b-a2b2-4e77-8d24-66f70dd59404","link":"/api/v1.1/game/748551/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-20T00:03:00Z","officialDate":"2023-10-19","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":10,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":3,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748551/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748551-2023-10-19","seasonDisplay":"2023","dayNight":"night","description":"ALCS
+        Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748550,"gameGuid":"7fb23b17-f091-4514-8840-7d4570ed2595","link":"/api/v1.1/game/748550/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-20T21:07:00Z","officialDate":"2023-10-20","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":2,"pct":".600"},"score":5,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":3,"pct":".400"},"score":4,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"content":{"link":"/api/v1/game/748550/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748550-2023-10-20","seasonDisplay":"2023","dayNight":"day","description":"ALCS
+        Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748549,"gameGuid":"9aa2d810-325a-4c2a-826e-c2e5df32eace","link":"/api/v1.1/game/748549/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-23T00:03:00Z","officialDate":"2023-10-22","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":3,"pct":".500"},"score":9,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":3,"losses":3,"pct":".500"},"score":2,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748549/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748549-2023-10-22","seasonDisplay":"2023","dayNight":"night","description":"ALCS
+        Game 6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":6,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748547,"gameGuid":"76257a6c-7b63-4794-bff0-9f22ec32391d","link":"/api/v1.1/game/748547/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-24T00:03:00Z","officialDate":"2023-10-23","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":4,"losses":3,"pct":".571"},"score":11,"team":{"id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":3,"losses":4,"pct":".429"},"score":4,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/748547/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748547-2023-10-23","seasonDisplay":"2023","dayNight":"night","description":"ALCS
+        Game 7","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":7,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"L_2","sortNumber":0,"isDefault":false,"gameType":"L"},"totalItems":7,"totalGames":7,"totalGamesInProgress":0,"games":[{"gamePk":748543,"gameGuid":"8980ea51-c664-473a-acc9-99bccbcb6e65","link":"/api/v1.1/game/748543/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-17T00:07:00Z","officialDate":"2023-10-16","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":3,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":5,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748543/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748543-2023-10-16","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748546,"gameGuid":"d4eb05c9-56a8-4faa-aa89-6ffa0f82bd80","link":"/api/v1.1/game/748546/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-18T00:07:00Z","officialDate":"2023-10-17","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":0,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":10,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748546/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748546-2023-10-17","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748545,"gameGuid":"6fdf6ff5-4bfa-4122-8c54-01c82cb330c1","link":"/api/v1.1/game/748545/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-19T21:07:00Z","officialDate":"2023-10-19","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":1,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":2,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748545/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748545-2023-10-19","seasonDisplay":"2023","dayNight":"day","description":"NLCS
+        Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748544,"gameGuid":"1db410be-75fc-473b-96b9-6248ea5d8848","link":"/api/v1.1/game/748544/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-21T00:07:00Z","officialDate":"2023-10-20","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":5,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":6,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748544/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748544-2023-10-20","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748538,"gameGuid":"4a993d1d-9798-4935-88a9-0ddae932fde3","link":"/api/v1.1/game/748538/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-22T00:07:00Z","officialDate":"2023-10-21","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":2,"pct":".600"},"score":6,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":3,"pct":".400"},"score":1,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"content":{"link":"/api/v1/game/748538/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748538-2023-10-21","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748539,"gameGuid":"b720ff3b-6b43-4ba9-b3ee-2972bc78d312","link":"/api/v1.1/game/748539/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-23T21:07:00Z","officialDate":"2023-10-23","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":3,"pct":".500"},"score":5,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":3,"losses":3,"pct":".500"},"score":1,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748539/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748539-2023-10-23","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":6,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":748537,"gameGuid":"ceaa7391-b0d2-4b26-81f8-7d9b61d5cf40","link":"/api/v1.1/game/748537/feed/live","gameType":"L","season":"2023","gameDate":"2023-10-25T00:07:00Z","officialDate":"2023-10-24","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":4,"losses":3,"pct":".571"},"score":4,"team":{"id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":3,"losses":4,"pct":".429"},"score":2,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/748537/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-748537-2023-10-24","seasonDisplay":"2023","dayNight":"night","description":"NLCS
+        Game 7","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":175,"gamesInSeries":7,"seriesGameNumber":7,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0}]}'
+  recorded_at: Fri, 26 Sep 2025 17:40:33 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Sync_Mlb_Client/_fetch_postseason/for_the_2024_playoffs/returns_the_JSON_from_the_2024_postseason_series_endpoint.yml
+++ b/spec/cassettes/Sync_Mlb_Client/_fetch_postseason/for_the_2024_playoffs/returns_the_JSON_from_the_2024_postseason_series_endpoint.yml
@@ -1,0 +1,320 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://statsapi.mlb.com/api/v1/schedule/postseason/series?season=2024
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.8.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '4826'
+      cache-control:
+      - max-age=20, public, stale-while-revalidate=30, stale-if-error=86400
+      expires:
+      - Fri, 26 Sep 2025 17:40:53 GMT
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      access-control-allow-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-expose-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      via:
+      - 1.1 google, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      age:
+      - '0'
+      date:
+      - Fri, 26 Sep 2025 17:40:33 GMT
+      x-served-by:
+      - cache-iad-kiad7000105-IAD, cache-lga21971-LGA
+      x-cache:
+      - MISS, MISS
+      x-cache-hits:
+      - 0, 0
+      x-timer:
+      - S1758908434.620364,VS0,VE84
+      vary:
+      - accept-encoding, Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"copyright":"Copyright 2025 MLB Advanced Media, L.P.  Use of any content
+        on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt","totalItems":43,"totalEvents":0,"totalGames":43,"totalGamesInProgress":0,"wait":10,"series":[{"series":{"id":"W_1","sortNumber":1,"isDefault":true,"gameType":"W"},"totalItems":5,"totalGames":5,"totalGamesInProgress":0,"games":[{"gamePk":775300,"gameGuid":"fb97fd78-be7e-4439-b30c-733a91400fbf","link":"/api/v1.1/game/775300/feed/live","gameType":"W","season":"2024","gameDate":"2024-10-26T00:08:00Z","officialDate":"2024-10-25","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":3,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775300/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775300-2024-10-25","seasonDisplay":"2024","dayNight":"night","description":"World
+        Series Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775294,"gameGuid":"e8d50a03-7c3f-44f5-87bb-43476e34fe94","link":"/api/v1.1/game/775294/feed/live","gameType":"W","season":"2024","gameDate":"2024-10-27T00:08:00Z","officialDate":"2024-10-26","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":2,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":4,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775294/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775294-2024-10-26","seasonDisplay":"2024","dayNight":"night","description":"World
+        Series Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775298,"gameGuid":"e6fed413-e8ca-4217-bdf0-d13912b4411a","link":"/api/v1.1/game/775298/feed/live","gameType":"W","season":"2024","gameDate":"2024-10-29T00:08:00Z","officialDate":"2024-10-28","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":0,"pct":"1.000"},"score":4,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":3,"pct":".000"},"score":2,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775298/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775298-2024-10-28","seasonDisplay":"2024","dayNight":"night","description":"World
+        Series Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775297,"gameGuid":"79cb2c8c-d698-49f7-9c33-0bb7a6895efb","link":"/api/v1.1/game/775297/feed/live","gameType":"W","season":"2024","gameDate":"2024-10-30T00:08:00Z","officialDate":"2024-10-29","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":4,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":11,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775297/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775297-2024-10-29","seasonDisplay":"2024","dayNight":"night","description":"World
+        Series Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775296,"gameGuid":"920f8c2c-a626-4716-9ffb-89b3059e2dfe","link":"/api/v1.1/game/775296/feed/live","gameType":"W","season":"2024","gameDate":"2024-10-31T00:08:00Z","officialDate":"2024-10-30","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":4,"losses":1,"pct":".800"},"score":7,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":4,"pct":".200"},"score":6,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775296/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775296-2024-10-30","seasonDisplay":"2024","dayNight":"night","description":"World
+        Series Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"World
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":1},{"series":{"id":"F_2","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":775343,"gameGuid":"bdc94e2d-6fc5-4142-a631-2e79734119c4","link":"/api/v1.1/game/775343/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-01T20:08:00Z","officialDate":"2024-10-01","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":1,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2,"name":"Oriole
+        Park at Camden Yards","link":"/api/v1/venues/2"},"content":{"link":"/api/v1/game/775343/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775343-2024-10-01","seasonDisplay":"2024","dayNight":"day","description":"AL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775341,"gameGuid":"df087a55-ce92-4c79-a6ef-ac84f45e7ac6","link":"/api/v1.1/game/775341/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-02T20:38:00Z","officialDate":"2024-10-02","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":2,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":1,"team":{"id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2,"name":"Oriole
+        Park at Camden Yards","link":"/api/v1/venues/2"},"content":{"link":"/api/v1/game/775341/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775341-2024-10-02","seasonDisplay":"2024","dayNight":"day","description":"AL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_1","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":775345,"gameGuid":"6b7b7364-6d16-4191-8f70-8e9678a067a7","link":"/api/v1.1/game/775345/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-01T18:32:00Z","officialDate":"2024-10-01","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":3,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":1,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/775345/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775345-2024-10-01","seasonDisplay":"2024","dayNight":"day","description":"AL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775344,"gameGuid":"ffb51248-46d5-43ae-bc40-944f5092b110","link":"/api/v1.1/game/775344/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-02T18:32:00Z","officialDate":"2024-10-02","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":5,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":2,"team":{"id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":2392,"name":"Minute
+        Maid Park","link":"/api/v1/venues/2392"},"content":{"link":"/api/v1/game/775344/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775344-2024-10-02","seasonDisplay":"2024","dayNight":"day","description":"AL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_4","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":2,"totalGames":2,"totalGamesInProgress":0,"games":[{"gamePk":775333,"gameGuid":"beab8b9e-91b3-4f3e-b40b-52fe8da07e20","link":"/api/v1.1/game/775333/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-02T00:38:00Z","officialDate":"2024-10-01","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":4,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2680,"name":"Petco
+        Park","link":"/api/v1/venues/2680"},"content":{"link":"/api/v1/game/775333/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775333-2024-10-01","seasonDisplay":"2024","dayNight":"night","description":"NL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775336,"gameGuid":"75c10c28-3c6d-4b0d-8061-91f2d3317ad5","link":"/api/v1.1/game/775336/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-03T00:38:00Z","officialDate":"2024-10-02","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":4,"team":{"id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":5,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2680,"name":"Petco
+        Park","link":"/api/v1/venues/2680"},"content":{"link":"/api/v1/game/775336/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775336-2024-10-02","seasonDisplay":"2024","dayNight":"night","description":"NL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"F_3","sortNumber":0,"isDefault":false,"gameType":"F"},"totalItems":3,"totalGames":3,"totalGamesInProgress":0,"games":[{"gamePk":775340,"gameGuid":"777e37a4-6a87-4849-82d2-006934e0cabb","link":"/api/v1.1/game/775340/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-01T21:32:00Z","officialDate":"2024-10-01","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":8,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":4,"team":{"id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"content":{"link":"/api/v1/game/775340/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775340-2024-10-01","seasonDisplay":"2024","dayNight":"day","description":"NL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":1,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775339,"gameGuid":"9366e3e4-f8d5-4375-bc3b-36866d265440","link":"/api/v1.1/game/775339/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-02T23:38:00Z","officialDate":"2024-10-02","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":3,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":5,"team":{"id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"content":{"link":"/api/v1/game/775339/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775339-2024-10-02","seasonDisplay":"2024","dayNight":"night","description":"NL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":2,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775337,"gameGuid":"487c2d33-3fc3-4775-8f7c-dd1a976ca46f","link":"/api/v1.1/game/775337/feed/live","gameType":"F","season":"2024","gameDate":"2024-10-03T23:08:00Z","officialDate":"2024-10-03","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":4,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":2,"team":{"id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"content":{"link":"/api/v1/game/775337/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775337-2024-10-03","seasonDisplay":"2024","dayNight":"night","description":"NL
+        Wild Card Series ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":3,"seriesGameNumber":3,"seriesDescription":"Wild
+        Card","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_2","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":5,"totalGames":5,"totalGamesInProgress":0,"games":[{"gamePk":775324,"gameGuid":"efca7c76-fb62-4ca8-9152-beb9125ce64a","link":"/api/v1.1/game/775324/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-05T17:08:00Z","officialDate":"2024-10-05","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":7,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775324/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775324-2024-10-05","seasonDisplay":"2024","dayNight":"day","description":"ALDS
+        ''B'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775325,"gameGuid":"700582b2-28f7-4267-80a3-c430a97fd85b","link":"/api/v1.1/game/775325/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-07T20:08:00Z","officialDate":"2024-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":3,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":0,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775325/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775325-2024-10-07","seasonDisplay":"2024","dayNight":"day","description":"ALDS
+        ''B'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775328,"gameGuid":"4d4441cb-122e-4742-a386-3dfdd789152c","link":"/api/v1.1/game/775328/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-09T19:08:00Z","officialDate":"2024-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":0,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":3,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2394,"name":"Comerica
+        Park","link":"/api/v1/venues/2394"},"content":{"link":"/api/v1/game/775328/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775328-2024-10-09","seasonDisplay":"2024","dayNight":"day","description":"ALDS
+        ''B'' Game 3 - Time Subject to Change","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775327,"gameGuid":"7c32e7a6-99a8-462d-b2d9-061d8675b5e4","link":"/api/v1.1/game/775327/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-10T22:08:00Z","officialDate":"2024-10-10","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":5,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":4,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":2394,"name":"Comerica
+        Park","link":"/api/v1/venues/2394"},"content":{"link":"/api/v1/game/775327/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775327-2024-10-10","seasonDisplay":"2024","dayNight":"night","description":"ALDS
+        ''B'' Game 4 - Time Subject to Change","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775326,"gameGuid":"4c8f2b4d-fe97-48fb-b9d6-507136a51b1f","link":"/api/v1.1/game/775326/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-12T17:08:00Z","officialDate":"2024-10-12","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":3,"pct":".400"},"score":3,"team":{"id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":3,"losses":2,"pct":".600"},"score":7,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775326/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775326-2024-10-12","seasonDisplay":"2024","dayNight":"day","description":"ALDS
+        ''B'' Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":5,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_1","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":4,"totalGames":4,"totalGamesInProgress":0,"games":[{"gamePk":775334,"gameGuid":"7e882e01-4a67-4a02-a89a-b3ecaa0650f2","link":"/api/v1.1/game/775334/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-05T22:38:00Z","officialDate":"2024-10-05","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":5,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775334/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775334-2024-10-05","seasonDisplay":"2024","dayNight":"night","description":"ALDS
+        ''A'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775332,"gameGuid":"29a570ab-4b81-43de-93cd-c124d93bf791","link":"/api/v1.1/game/775332/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-07T23:38:00Z","officialDate":"2024-10-07","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":4,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":2,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775332/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775332-2024-10-07","seasonDisplay":"2024","dayNight":"night","description":"ALDS
+        ''A'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775329,"gameGuid":"da66f490-b46c-4171-8a80-84539e6d54ee","link":"/api/v1.1/game/775329/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-09T23:08:00Z","officialDate":"2024-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":3,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":2,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":7,"name":"Kauffman
+        Stadium","link":"/api/v1/venues/7"},"content":{"link":"/api/v1/game/775329/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775329-2024-10-09","seasonDisplay":"2024","dayNight":"night","description":"ALDS
+        ''A'' Game 3 - Time Subject to Change","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775331,"gameGuid":"417aa3a4-784f-497e-8a45-8ab70a8ca03d","link":"/api/v1.1/game/775331/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-11T00:08:00Z","officialDate":"2024-10-10","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":3,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":1,"team":{"id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":7,"name":"Kauffman
+        Stadium","link":"/api/v1/venues/7"},"content":{"link":"/api/v1/game/775331/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775331-2024-10-10","seasonDisplay":"2024","dayNight":"night","description":"ALDS
+        ''A'' Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_4","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":4,"totalGames":4,"totalGamesInProgress":0,"games":[{"gamePk":775318,"gameGuid":"34c4e5a0-3cff-4583-a7ed-143c5538a456","link":"/api/v1.1/game/775318/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-05T20:08:00Z","officialDate":"2024-10-05","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":6,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":2,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/775318/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775318-2024-10-05","seasonDisplay":"2024","dayNight":"day","description":"NLDS
+        ''B'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775319,"gameGuid":"52255605-6815-430f-a06e-1ca5a022e272","link":"/api/v1.1/game/775319/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-06T20:08:00Z","officialDate":"2024-10-06","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":6,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":7,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"content":{"link":"/api/v1/game/775319/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775319-2024-10-06","seasonDisplay":"2024","dayNight":"day","description":"NLDS
+        ''B'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775316,"gameGuid":"09bf2969-9af6-4597-9a96-1408b76861f6","link":"/api/v1.1/game/775316/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-08T21:08:00Z","officialDate":"2024-10-08","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":2,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":7,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"content":{"link":"/api/v1/game/775316/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775316-2024-10-08","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''B'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775313,"gameGuid":"9b39f114-8cfd-411d-89ec-c06550e6df54","link":"/api/v1.1/game/775313/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-09T21:08:00Z","officialDate":"2024-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":1,"team":{"id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143"},"isWinner":false,"splitSquad":false,"seriesNumber":4},"home":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":4,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":4}},"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"content":{"link":"/api/v1/game/775313/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775313-2024-10-09","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''B'' Game 4 - Time Subject to Change","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"D_3","sortNumber":0,"isDefault":false,"gameType":"D"},"totalItems":5,"totalGames":5,"totalGamesInProgress":0,"games":[{"gamePk":775323,"gameGuid":"c23a88db-4970-401b-a664-c4d39c944e2b","link":"/api/v1.1/game/775323/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-06T00:38:00Z","officialDate":"2024-10-05","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":5,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":7,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775323/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775323-2024-10-05","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''A'' Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":1,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775322,"gameGuid":"b413d634-49e4-4725-96b9-4ec9c141c353","link":"/api/v1.1/game/775322/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-07T00:03:00Z","officialDate":"2024-10-06","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":10,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":2,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775322/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775322-2024-10-06","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''A'' Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":2,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775321,"gameGuid":"64cb6adc-8afb-49b6-bae8-c532f586c910","link":"/api/v1.1/game/775321/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-09T01:08:00Z","officialDate":"2024-10-08","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":5,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":6,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":2680,"name":"Petco
+        Park","link":"/api/v1/venues/2680"},"content":{"link":"/api/v1/game/775321/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775321-2024-10-08","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''A'' Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":3,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775320,"gameGuid":"6d2091d7-b508-4a1f-877d-d34d4e7ecb08","link":"/api/v1.1/game/775320/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-10T01:08:00Z","officialDate":"2024-10-09","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":8,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":2,"losses":2,"pct":".500"},"score":0,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":false,"splitSquad":false,"seriesNumber":3}},"venue":{"id":2680,"name":"Petco
+        Park","link":"/api/v1/venues/2680"},"content":{"link":"/api/v1/game/775320/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775320-2024-10-09","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''A'' Game 4 ","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":4,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775317,"gameGuid":"a498574b-4c7c-49c1-b862-2f9820534a39","link":"/api/v1.1/game/775317/feed/live","gameType":"D","season":"2024","gameDate":"2024-10-12T00:08:00Z","officialDate":"2024-10-11","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":3,"pct":".400"},"score":0,"team":{"id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135"},"isWinner":false,"splitSquad":false,"seriesNumber":3},"home":{"leagueRecord":{"wins":3,"losses":2,"pct":".600"},"score":2,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":3}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775317/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775317-2024-10-11","seasonDisplay":"2024","dayNight":"night","description":"NLDS
+        ''A'' Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":5,"seriesGameNumber":5,"seriesDescription":"Division
+        Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"L_2","sortNumber":0,"isDefault":false,"gameType":"L"},"totalItems":6,"totalGames":6,"totalGamesInProgress":0,"games":[{"gamePk":775307,"gameGuid":"a0b1f240-bf95-40a6-aa35-b7e7db23c390","link":"/api/v1.1/game/775307/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-14T00:15:00Z","officialDate":"2024-10-13","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":0,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":9,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775307/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775307-2024-10-13","seasonDisplay":"2024","dayNight":"night","description":"NLCS
+        Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775306,"gameGuid":"5d7ea2b9-b2cc-4719-b7ab-6b74e888ea77","link":"/api/v1.1/game/775306/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-14T20:08:00Z","officialDate":"2024-10-14","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":7,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":1,"pct":".500"},"score":3,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775306/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775306-2024-10-14","seasonDisplay":"2024","dayNight":"day","description":"NLCS
+        Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775305,"gameGuid":"e300ece1-b785-4c39-bacc-0887aa917b5a","link":"/api/v1.1/game/775305/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-17T00:08:00Z","officialDate":"2024-10-16","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":8,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":0,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"content":{"link":"/api/v1/game/775305/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775305-2024-10-16","seasonDisplay":"2024","dayNight":"night","description":"NLCS
+        Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775303,"gameGuid":"52332294-a6e1-4284-abd7-7458f68a52d7","link":"/api/v1.1/game/775303/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-18T00:08:00Z","officialDate":"2024-10-17","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":10,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":2,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":2}},"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"content":{"link":"/api/v1/game/775303/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775303-2024-10-17","seasonDisplay":"2024","dayNight":"night","description":"NLCS
+        Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775299,"gameGuid":"eb02600d-3dd8-4604-826e-4f213f95e4ad","link":"/api/v1.1/game/775299/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-18T21:08:00Z","officialDate":"2024-10-18","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":2,"pct":".600"},"score":6,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":2,"losses":3,"pct":".400"},"score":12,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"content":{"link":"/api/v1/game/775299/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775299-2024-10-18","seasonDisplay":"2024","dayNight":"night","description":"NLCS
+        Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775302,"gameGuid":"1304189c-3a14-43b6-bb98-6d17a8aa0944","link":"/api/v1.1/game/775302/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-21T00:08:00Z","officialDate":"2024-10-20","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":4,"pct":".333"},"score":5,"team":{"id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121"},"isWinner":false,"splitSquad":false,"seriesNumber":2},"home":{"leagueRecord":{"wins":4,"losses":2,"pct":".667"},"score":10,"team":{"id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119"},"isWinner":true,"splitSquad":false,"seriesNumber":2}},"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"content":{"link":"/api/v1/game/775302/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775302-2024-10-20","seasonDisplay":"2024","dayNight":"night","description":"NLCS
+        Game 6","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":6,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0},{"series":{"id":"L_1","sortNumber":0,"isDefault":false,"gameType":"L"},"totalItems":5,"totalGames":5,"totalGamesInProgress":0,"games":[{"gamePk":775314,"gameGuid":"2b156ddc-cfd4-4be6-9407-d666a20094c3","link":"/api/v1.1/game/775314/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-14T23:38:00Z","officialDate":"2024-10-14","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":1,"pct":".000"},"score":2,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":0,"pct":"1.000"},"score":5,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775314/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775314-2024-10-14","seasonDisplay":"2024","dayNight":"night","description":"ALCS
+        Game 1","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":1,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775312,"gameGuid":"cda6d84d-bf87-490c-b86f-55d2ef9b1378","link":"/api/v1.1/game/775312/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-15T23:38:00Z","officialDate":"2024-10-15","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":0,"losses":2,"pct":".000"},"score":3,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":2,"losses":0,"pct":"1.000"},"score":6,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"content":{"link":"/api/v1/game/775312/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775312-2024-10-15","seasonDisplay":"2024","dayNight":"night","description":"ALCS
+        Game 2","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":2,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775310,"gameGuid":"9eb792f0-9f97-4d09-81fb-d40d92458bd4","link":"/api/v1.1/game/775310/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-17T21:08:00Z","officialDate":"2024-10-17","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":2,"losses":1,"pct":".667"},"score":5,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":false,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":2,"pct":".333"},"score":7,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":true,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775310/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775310-2024-10-17","seasonDisplay":"2024","dayNight":"night","description":"ALCS
+        Game 3","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":3,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775311,"gameGuid":"98e7f2be-754a-4748-8bac-2b5ab0a75fc1","link":"/api/v1.1/game/775311/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-19T00:08:00Z","officialDate":"2024-10-18","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":3,"losses":1,"pct":".750"},"score":8,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":3,"pct":".250"},"score":6,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775311/content"},"isTie":false,"isFeaturedGame":false,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775311-2024-10-18","seasonDisplay":"2024","dayNight":"night","description":"ALCS
+        Game 4","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":4,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"},{"gamePk":775309,"gameGuid":"0d0cc33e-4170-4e1d-8cd8-1335663611bb","link":"/api/v1.1/game/775309/feed/live","gameType":"L","season":"2024","gameDate":"2024-10-20T00:08:00Z","officialDate":"2024-10-19","status":{"abstractGameState":"Final","codedGameState":"F","detailedState":"Final","statusCode":"F","startTimeTBD":false,"abstractGameCode":"F"},"teams":{"away":{"leagueRecord":{"wins":4,"losses":1,"pct":".800"},"score":5,"team":{"id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147"},"isWinner":true,"splitSquad":false,"seriesNumber":1},"home":{"leagueRecord":{"wins":1,"losses":4,"pct":".200"},"score":2,"team":{"id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114"},"isWinner":false,"splitSquad":false,"seriesNumber":1}},"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"content":{"link":"/api/v1/game/775309/content"},"isTie":false,"isFeaturedGame":true,"gameNumber":1,"publicFacing":true,"doubleHeader":"N","gamedayType":"P","tiebreaker":"N","calendarEventID":"14-775309-2024-10-19","seasonDisplay":"2024","dayNight":"night","description":"ALCS
+        Game 5","scheduledInnings":9,"reverseHomeAwayStatus":false,"inningBreakLength":120,"gamesInSeries":7,"seriesGameNumber":5,"seriesDescription":"League
+        Championship Series","recordSource":"S","ifNecessary":"N","ifNecessaryDescription":"Normal
+        Game"}],"sortOrder":0}]}'
+  recorded_at: Fri, 26 Sep 2025 17:40:33 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Sync_Mlb_Client/_fetch_teams/returns_the_JSON_from_the_teams_endpoint.yml
+++ b/spec/cassettes/Sync_Mlb_Client/_fetch_teams/returns_the_JSON_from_the_teams_endpoint.yml
@@ -1,0 +1,244 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://statsapi.mlb.com/api/v1/teams?sportId=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.8.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      connection:
+      - keep-alive
+      content-length:
+      - '2916'
+      cache-control:
+      - max-age=60, public, stale-while-revalidate=30, stale-if-error=86400
+      expires:
+      - Fri, 26 Sep 2025 17:40:52 GMT
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      access-control-allow-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-expose-headers:
+      - Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      via:
+      - 1.1 google, 1.1 varnish, 1.1 varnish
+      accept-ranges:
+      - bytes
+      date:
+      - Fri, 26 Sep 2025 17:40:34 GMT
+      age:
+      - '41'
+      x-served-by:
+      - cache-iad-kiad7000087-IAD, cache-lga21939-LGA
+      x-cache:
+      - HIT, HIT
+      x-cache-hits:
+      - 14, 1
+      x-timer:
+      - S1758908434.093219,VS0,VE2
+      vary:
+      - accept-encoding, Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"copyright":"Copyright 2025 MLB Advanced Media, L.P.  Use of any content
+        on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt","teams":[{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":133,"name":"Athletics","link":"/api/v1/teams/133","season":2025,"venue":{"id":2529,"name":"Sutter
+        Health Park","link":"/api/v1/venues/2529"},"springVenue":{"id":2507,"link":"/api/v1/venues/2507"},"teamCode":"ath","fileCode":"ath","abbreviation":"ATH","teamName":"Athletics","locationName":"Sacramento","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":200,"name":"American
+        League West","link":"/api/v1/divisions/200"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Athletics","franchiseName":"Athletics","clubName":"Athletics","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":134,"name":"Pittsburgh
+        Pirates","link":"/api/v1/teams/134","season":2025,"venue":{"id":31,"name":"PNC
+        Park","link":"/api/v1/venues/31"},"springVenue":{"id":2526,"link":"/api/v1/venues/2526"},"teamCode":"pit","fileCode":"pit","abbreviation":"PIT","teamName":"Pirates","locationName":"Pittsburgh","firstYearOfPlay":"1882","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":205,"name":"National
+        League Central","link":"/api/v1/divisions/205"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Pittsburgh","franchiseName":"Pittsburgh","clubName":"Pirates","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":135,"name":"San
+        Diego Padres","link":"/api/v1/teams/135","season":2025,"venue":{"id":2680,"name":"Petco
+        Park","link":"/api/v1/venues/2680"},"springVenue":{"id":2530,"link":"/api/v1/venues/2530"},"teamCode":"sdn","fileCode":"sd","abbreviation":"SD","teamName":"Padres","locationName":"San
+        Diego","firstYearOfPlay":"1968","league":{"id":104,"name":"National League","link":"/api/v1/league/104"},"division":{"id":203,"name":"National
+        League West","link":"/api/v1/divisions/203"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"San Diego","franchiseName":"San Diego","clubName":"Padres","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":136,"name":"Seattle
+        Mariners","link":"/api/v1/teams/136","season":2025,"venue":{"id":680,"name":"T-Mobile
+        Park","link":"/api/v1/venues/680"},"springVenue":{"id":2530,"link":"/api/v1/venues/2530"},"teamCode":"sea","fileCode":"sea","abbreviation":"SEA","teamName":"Mariners","locationName":"Seattle","firstYearOfPlay":"1977","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":200,"name":"American
+        League West","link":"/api/v1/divisions/200"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Seattle","franchiseName":"Seattle","clubName":"Mariners","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":137,"name":"San
+        Francisco Giants","link":"/api/v1/teams/137","season":2025,"venue":{"id":2395,"name":"Oracle
+        Park","link":"/api/v1/venues/2395"},"springVenue":{"id":2532,"link":"/api/v1/venues/2532"},"teamCode":"sfn","fileCode":"sf","abbreviation":"SF","teamName":"Giants","locationName":"San
+        Francisco","firstYearOfPlay":"1883","league":{"id":104,"name":"National League","link":"/api/v1/league/104"},"division":{"id":203,"name":"National
+        League West","link":"/api/v1/divisions/203"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"San Francisco","franchiseName":"San Francisco","clubName":"Giants","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":138,"name":"St.
+        Louis Cardinals","link":"/api/v1/teams/138","season":2025,"venue":{"id":2889,"name":"Busch
+        Stadium","link":"/api/v1/venues/2889"},"springVenue":{"id":2520,"link":"/api/v1/venues/2520"},"teamCode":"sln","fileCode":"stl","abbreviation":"STL","teamName":"Cardinals","locationName":"St.
+        Louis","firstYearOfPlay":"1892","league":{"id":104,"name":"National League","link":"/api/v1/league/104"},"division":{"id":205,"name":"National
+        League Central","link":"/api/v1/divisions/205"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"St. Louis","franchiseName":"St. Louis","clubName":"Cardinals","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":139,"name":"Tampa
+        Bay Rays","link":"/api/v1/teams/139","season":2025,"venue":{"id":2523,"name":"George
+        M. Steinbrenner Field","link":"/api/v1/venues/2523"},"springVenue":{"id":2534,"link":"/api/v1/venues/2534"},"teamCode":"tba","fileCode":"tb","abbreviation":"TB","teamName":"Rays","locationName":"Tampa","firstYearOfPlay":"1996","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":201,"name":"American
+        League East","link":"/api/v1/divisions/201"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Tampa Bay","franchiseName":"Tampa Bay","clubName":"Rays","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":140,"name":"Texas
+        Rangers","link":"/api/v1/teams/140","season":2025,"venue":{"id":5325,"name":"Globe
+        Life Field","link":"/api/v1/venues/5325"},"springVenue":{"id":2603,"link":"/api/v1/venues/2603"},"teamCode":"tex","fileCode":"tex","abbreviation":"TEX","teamName":"Rangers","locationName":"Arlington","firstYearOfPlay":"1961","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":200,"name":"American
+        League West","link":"/api/v1/divisions/200"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Texas","franchiseName":"Texas","clubName":"Rangers","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":141,"name":"Toronto
+        Blue Jays","link":"/api/v1/teams/141","season":2025,"venue":{"id":14,"name":"Rogers
+        Centre","link":"/api/v1/venues/14"},"springVenue":{"id":2536,"link":"/api/v1/venues/2536"},"teamCode":"tor","fileCode":"tor","abbreviation":"TOR","teamName":"Blue
+        Jays","locationName":"Toronto","firstYearOfPlay":"1977","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":201,"name":"American
+        League East","link":"/api/v1/divisions/201"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Toronto","franchiseName":"Toronto","clubName":"Blue
+        Jays","active":true},{"springLeague":{"id":115,"name":"Grapefruit League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":142,"name":"Minnesota
+        Twins","link":"/api/v1/teams/142","season":2025,"venue":{"id":3312,"name":"Target
+        Field","link":"/api/v1/venues/3312"},"springVenue":{"id":2862,"link":"/api/v1/venues/2862"},"teamCode":"min","fileCode":"min","abbreviation":"MIN","teamName":"Twins","locationName":"Minneapolis","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":202,"name":"American
+        League Central","link":"/api/v1/divisions/202"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Minnesota","franchiseName":"Minnesota","clubName":"Twins","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":143,"name":"Philadelphia
+        Phillies","link":"/api/v1/teams/143","season":2025,"venue":{"id":2681,"name":"Citizens
+        Bank Park","link":"/api/v1/venues/2681"},"springVenue":{"id":2700,"link":"/api/v1/venues/2700"},"teamCode":"phi","fileCode":"phi","abbreviation":"PHI","teamName":"Phillies","locationName":"Philadelphia","firstYearOfPlay":"1883","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":204,"name":"National
+        League East","link":"/api/v1/divisions/204"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Philadelphia","franchiseName":"Philadelphia","clubName":"Phillies","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":144,"name":"Atlanta
+        Braves","link":"/api/v1/teams/144","season":2025,"venue":{"id":4705,"name":"Truist
+        Park","link":"/api/v1/venues/4705"},"springVenue":{"id":5380,"link":"/api/v1/venues/5380"},"teamCode":"atl","fileCode":"atl","abbreviation":"ATL","teamName":"Braves","locationName":"Atlanta","firstYearOfPlay":"1871","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":204,"name":"National
+        League East","link":"/api/v1/divisions/204"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Atlanta","franchiseName":"Atlanta","clubName":"Braves","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":145,"name":"Chicago
+        White Sox","link":"/api/v1/teams/145","season":2025,"venue":{"id":4,"name":"Rate
+        Field","link":"/api/v1/venues/4"},"springVenue":{"id":3809,"link":"/api/v1/venues/3809"},"teamCode":"cha","fileCode":"cws","abbreviation":"CWS","teamName":"White
+        Sox","locationName":"Chicago","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":202,"name":"American
+        League Central","link":"/api/v1/divisions/202"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Chi White Sox","franchiseName":"Chicago","clubName":"White
+        Sox","active":true},{"springLeague":{"id":115,"name":"Grapefruit League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":146,"name":"Miami
+        Marlins","link":"/api/v1/teams/146","season":2025,"venue":{"id":4169,"name":"loanDepot
+        park","link":"/api/v1/venues/4169"},"springVenue":{"id":2520,"link":"/api/v1/venues/2520"},"teamCode":"mia","fileCode":"mia","abbreviation":"MIA","teamName":"Marlins","locationName":"Miami","firstYearOfPlay":"1991","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":204,"name":"National
+        League East","link":"/api/v1/divisions/204"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Miami","franchiseName":"Miami","clubName":"Marlins","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":147,"name":"New
+        York Yankees","link":"/api/v1/teams/147","season":2025,"venue":{"id":3313,"name":"Yankee
+        Stadium","link":"/api/v1/venues/3313"},"springVenue":{"id":2523,"link":"/api/v1/venues/2523"},"teamCode":"nya","fileCode":"nyy","abbreviation":"NYY","teamName":"Yankees","locationName":"Bronx","firstYearOfPlay":"1903","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":201,"name":"American
+        League East","link":"/api/v1/divisions/201"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"NY Yankees","franchiseName":"New York","clubName":"Yankees","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":158,"name":"Milwaukee
+        Brewers","link":"/api/v1/teams/158","season":2025,"venue":{"id":32,"name":"American
+        Family Field","link":"/api/v1/venues/32"},"springVenue":{"id":2518,"link":"/api/v1/venues/2518"},"teamCode":"mil","fileCode":"mil","abbreviation":"MIL","teamName":"Brewers","locationName":"Milwaukee","firstYearOfPlay":"1968","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":205,"name":"National
+        League Central","link":"/api/v1/divisions/205"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Milwaukee","franchiseName":"Milwaukee","clubName":"Brewers","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":108,"name":"Los
+        Angeles Angels","link":"/api/v1/teams/108","season":2025,"venue":{"id":1,"name":"Angel
+        Stadium","link":"/api/v1/venues/1"},"springVenue":{"id":2500,"link":"/api/v1/venues/2500"},"teamCode":"ana","fileCode":"ana","abbreviation":"LAA","teamName":"Angels","locationName":"Anaheim","firstYearOfPlay":"1961","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":200,"name":"American
+        League West","link":"/api/v1/divisions/200"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"LA Angels","franchiseName":"Los Angeles","clubName":"Angels","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":109,"name":"Arizona
+        Diamondbacks","link":"/api/v1/teams/109","season":2025,"venue":{"id":15,"name":"Chase
+        Field","link":"/api/v1/venues/15"},"springVenue":{"id":4249,"link":"/api/v1/venues/4249"},"teamCode":"ari","fileCode":"ari","abbreviation":"AZ","teamName":"D-backs","locationName":"Phoenix","firstYearOfPlay":"1996","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":203,"name":"National
+        League West","link":"/api/v1/divisions/203"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Arizona","franchiseName":"Arizona","clubName":"Diamondbacks","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":110,"name":"Baltimore
+        Orioles","link":"/api/v1/teams/110","season":2025,"venue":{"id":2,"name":"Oriole
+        Park at Camden Yards","link":"/api/v1/venues/2"},"springVenue":{"id":2508,"link":"/api/v1/venues/2508"},"teamCode":"bal","fileCode":"bal","abbreviation":"BAL","teamName":"Orioles","locationName":"Baltimore","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":201,"name":"American
+        League East","link":"/api/v1/divisions/201"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Baltimore","franchiseName":"Baltimore","clubName":"Orioles","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":111,"name":"Boston
+        Red Sox","link":"/api/v1/teams/111","season":2025,"venue":{"id":3,"name":"Fenway
+        Park","link":"/api/v1/venues/3"},"springVenue":{"id":4309,"link":"/api/v1/venues/4309"},"teamCode":"bos","fileCode":"bos","abbreviation":"BOS","teamName":"Red
+        Sox","locationName":"Boston","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":201,"name":"American
+        League East","link":"/api/v1/divisions/201"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Boston","franchiseName":"Boston","clubName":"Red
+        Sox","active":true},{"springLeague":{"id":114,"name":"Cactus League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":112,"name":"Chicago
+        Cubs","link":"/api/v1/teams/112","season":2025,"venue":{"id":17,"name":"Wrigley
+        Field","link":"/api/v1/venues/17"},"springVenue":{"id":4629,"link":"/api/v1/venues/4629"},"teamCode":"chn","fileCode":"chc","abbreviation":"CHC","teamName":"Cubs","locationName":"Chicago","firstYearOfPlay":"1874","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":205,"name":"National
+        League Central","link":"/api/v1/divisions/205"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Chi Cubs","franchiseName":"Chicago","clubName":"Cubs","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":113,"name":"Cincinnati
+        Reds","link":"/api/v1/teams/113","season":2025,"venue":{"id":2602,"name":"Great
+        American Ball Park","link":"/api/v1/venues/2602"},"springVenue":{"id":3834,"link":"/api/v1/venues/3834"},"teamCode":"cin","fileCode":"cin","abbreviation":"CIN","teamName":"Reds","locationName":"Cincinnati","firstYearOfPlay":"1882","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":205,"name":"National
+        League Central","link":"/api/v1/divisions/205"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Cincinnati","franchiseName":"Cincinnati","clubName":"Reds","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":114,"name":"Cleveland
+        Guardians","link":"/api/v1/teams/114","season":2025,"venue":{"id":5,"name":"Progressive
+        Field","link":"/api/v1/venues/5"},"springVenue":{"id":3834,"link":"/api/v1/venues/3834"},"teamCode":"cle","fileCode":"cle","abbreviation":"CLE","teamName":"Guardians","locationName":"Cleveland","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":202,"name":"American
+        League Central","link":"/api/v1/divisions/202"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Cleveland","franchiseName":"Cleveland","clubName":"Guardians","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":115,"name":"Colorado
+        Rockies","link":"/api/v1/teams/115","season":2025,"venue":{"id":19,"name":"Coors
+        Field","link":"/api/v1/venues/19"},"springVenue":{"id":4249,"link":"/api/v1/venues/4249"},"teamCode":"col","fileCode":"col","abbreviation":"COL","teamName":"Rockies","locationName":"Denver","firstYearOfPlay":"1992","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":203,"name":"National
+        League West","link":"/api/v1/divisions/203"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Colorado","franchiseName":"Colorado","clubName":"Rockies","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":116,"name":"Detroit
+        Tigers","link":"/api/v1/teams/116","season":2025,"venue":{"id":2394,"name":"Comerica
+        Park","link":"/api/v1/venues/2394"},"springVenue":{"id":2511,"link":"/api/v1/venues/2511"},"teamCode":"det","fileCode":"det","abbreviation":"DET","teamName":"Tigers","locationName":"Detroit","firstYearOfPlay":"1901","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":202,"name":"American
+        League Central","link":"/api/v1/divisions/202"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Detroit","franchiseName":"Detroit","clubName":"Tigers","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":117,"name":"Houston
+        Astros","link":"/api/v1/teams/117","season":2025,"venue":{"id":2392,"name":"Daikin
+        Park","link":"/api/v1/venues/2392"},"springVenue":{"id":5000,"link":"/api/v1/venues/5000"},"teamCode":"hou","fileCode":"hou","abbreviation":"HOU","teamName":"Astros","locationName":"Houston","firstYearOfPlay":"1962","league":{"id":103,"name":"American
+        League","link":"/api/v1/league/103"},"division":{"id":200,"name":"American
+        League West","link":"/api/v1/divisions/200"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Houston","franchiseName":"Houston","clubName":"Astros","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":118,"name":"Kansas
+        City Royals","link":"/api/v1/teams/118","season":2025,"venue":{"id":7,"name":"Kauffman
+        Stadium","link":"/api/v1/venues/7"},"springVenue":{"id":2603,"link":"/api/v1/venues/2603"},"teamCode":"kca","fileCode":"kc","abbreviation":"KC","teamName":"Royals","locationName":"Kansas
+        City","firstYearOfPlay":"1968","league":{"id":103,"name":"American League","link":"/api/v1/league/103"},"division":{"id":202,"name":"American
+        League Central","link":"/api/v1/divisions/202"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Kansas City","franchiseName":"Kansas City","clubName":"Royals","active":true},{"springLeague":{"id":114,"name":"Cactus
+        League","link":"/api/v1/league/114","abbreviation":"CL"},"allStarStatus":"N","id":119,"name":"Los
+        Angeles Dodgers","link":"/api/v1/teams/119","season":2025,"venue":{"id":22,"name":"Dodger
+        Stadium","link":"/api/v1/venues/22"},"springVenue":{"id":3809,"link":"/api/v1/venues/3809"},"teamCode":"lan","fileCode":"la","abbreviation":"LAD","teamName":"Dodgers","locationName":"Los
+        Angeles","firstYearOfPlay":"1884","league":{"id":104,"name":"National League","link":"/api/v1/league/104"},"division":{"id":203,"name":"National
+        League West","link":"/api/v1/divisions/203"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"LA Dodgers","franchiseName":"Los Angeles","clubName":"Dodgers","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":120,"name":"Washington
+        Nationals","link":"/api/v1/teams/120","season":2025,"venue":{"id":3309,"name":"Nationals
+        Park","link":"/api/v1/venues/3309"},"springVenue":{"id":5000,"link":"/api/v1/venues/5000"},"teamCode":"was","fileCode":"was","abbreviation":"WSH","teamName":"Nationals","locationName":"Washington","firstYearOfPlay":"1968","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":204,"name":"National
+        League East","link":"/api/v1/divisions/204"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"Washington","franchiseName":"Washington","clubName":"Nationals","active":true},{"springLeague":{"id":115,"name":"Grapefruit
+        League","link":"/api/v1/league/115","abbreviation":"GL"},"allStarStatus":"N","id":121,"name":"New
+        York Mets","link":"/api/v1/teams/121","season":2025,"venue":{"id":3289,"name":"Citi
+        Field","link":"/api/v1/venues/3289"},"springVenue":{"id":2856,"link":"/api/v1/venues/2856"},"teamCode":"nyn","fileCode":"nym","abbreviation":"NYM","teamName":"Mets","locationName":"Flushing","firstYearOfPlay":"1962","league":{"id":104,"name":"National
+        League","link":"/api/v1/league/104"},"division":{"id":204,"name":"National
+        League East","link":"/api/v1/divisions/204"},"sport":{"id":1,"link":"/api/v1/sports/1","name":"Major
+        League Baseball"},"shortName":"NY Mets","franchiseName":"New York","clubName":"Mets","active":true}]}'
+  recorded_at: Fri, 26 Sep 2025 17:40:34 GMT
+recorded_with: VCR 6.3.1

--- a/spec/lib/sync/mlb/client_spec.rb
+++ b/spec/lib/sync/mlb/client_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Sync::Mlb::Client do
+  describe "::fetch_postseason", :vcr do
+    subject { described_class.fetch_postseason(year) }
+
+    context "for the 2024 playoffs" do
+      let(:year) { 2024 }
+
+      it "returns the JSON from the 2024 postseason series endpoint" do
+        expect(subject[:series]).to be_an(Array)
+        expect(subject[:series]).not_to be_empty
+
+        random_series = subject[:series].sample
+        random_game = random_series[:games].sample
+        expect(random_game[:season]).to eq(year.to_s)
+      end
+    end
+
+    context "for the 2023 playoffs" do
+      let(:year) { 2023 }
+
+      it "returns the JSON from the 2023 postseason series endpoint" do
+        expect(subject[:series]).to be_an(Array)
+        expect(subject[:series]).not_to be_empty
+
+        random_series = subject[:series].sample
+        random_game = random_series[:games].sample
+        expect(random_game[:season]).to eq(year.to_s)
+      end
+    end
+  end
+
+  describe "::fetch_teams", :vcr do
+    subject { described_class.fetch_teams }
+
+    it "returns the JSON from the teams endpoint" do
+      should include(:teams)
+      expect(subject[:teams]).to be_an(Array)
+      expect(subject[:teams]).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/sync/mlb/matchups_spec.rb
+++ b/spec/lib/sync/mlb/matchups_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe Sync::Mlb::Matchups do
       }
     end
 
-    context "when series hasn't started and teams are unknown" do
+    shared_examples "series instance methods" do |series_id, game_type, league, expected_round, expected_conference, expected_number, home_team_id, away_team_id, expected_favorite_tricode, expected_underdog_tricode|
       let(:series_data) do
         {
           series: {
-            id: "F_1",
+            id: series_id,
             sortNumber: 1,
             isDefault: true,
-            gameType: "F"
+            gameType: game_type
           },
           totalItems: 3,
           totalGames: 3,
@@ -128,7 +128,7 @@ RSpec.describe Sync::Mlb::Matchups do
               gamePk: 813072,
               gameGuid: "302be26b-38e4-4555-ad7c-b94b17ebd0eb",
               link: "/api/v1.1/game/813072/feed/live",
-              gameType: "F",
+              gameType: game_type,
               season: "2025",
               gameDate: "2025-09-30T07:33:00Z",
               officialDate: "2025-09-30",
@@ -148,9 +148,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4946,
-                    name: "AL Wild Card #3",
-                    link: "/api/v1/teams/4946"
+                    id: away_team_id,
+                    name: "#{league} Wild Card #3",
+                    link: "/api/v1/teams/#{away_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -162,9 +162,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4614,
-                    name: "ALC1",
-                    link: "/api/v1/teams/4614"
+                    id: home_team_id,
+                    name: "#{league}C1",
+                    link: "/api/v1/teams/#{home_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -172,10 +172,10 @@ RSpec.describe Sync::Mlb::Matchups do
               },
               venue: {
                 id: 3832,
-                name: "AL Stadium",
+                name: "#{league} Stadium",
                 link: "/api/v1/venues/3832"
               },
-              description: "AL Wild Card 'A' Game 1",
+              description: "#{league} Wild Card 'A' Game 1",
               seriesGameNumber: 1,
               seriesDescription: "Wild Card"
             },
@@ -183,7 +183,7 @@ RSpec.describe Sync::Mlb::Matchups do
               gamePk: 813071,
               gameGuid: "fca403df-ecba-4340-b893-370ece3b6f7d",
               link: "/api/v1.1/game/813071/feed/live",
-              gameType: "F",
+              gameType: game_type,
               season: "2025",
               gameDate: "2025-10-01T07:33:00Z",
               officialDate: "2025-10-01",
@@ -203,9 +203,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4946,
-                    name: "AL Wild Card #3",
-                    link: "/api/v1/teams/4946"
+                    id: away_team_id,
+                    name: "#{league} Wild Card #3",
+                    link: "/api/v1/teams/#{away_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -217,9 +217,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4614,
-                    name: "ALC1",
-                    link: "/api/v1/teams/4614"
+                    id: home_team_id,
+                    name: "#{league}C1",
+                    link: "/api/v1/teams/#{home_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -227,10 +227,10 @@ RSpec.describe Sync::Mlb::Matchups do
               },
               venue: {
                 id: 3832,
-                name: "AL Stadium",
+                name: "#{league} Stadium",
                 link: "/api/v1/venues/3832"
               },
-              description: "AL Wild Card 'A' Game 2",
+              description: "#{league} Wild Card 'A' Game 2",
               seriesGameNumber: 2,
               seriesDescription: "Wild Card"
             },
@@ -238,7 +238,7 @@ RSpec.describe Sync::Mlb::Matchups do
               gamePk: 813073,
               gameGuid: "d69c1633-4f00-4b6d-b65d-55d29989a79c",
               link: "/api/v1.1/game/813073/feed/live",
-              gameType: "F",
+              gameType: game_type,
               season: "2025",
               gameDate: "2025-10-02T07:33:00Z",
               officialDate: "2025-10-02",
@@ -258,9 +258,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4946,
-                    name: "AL Wild Card #3",
-                    link: "/api/v1/teams/4946"
+                    id: away_team_id,
+                    name: "#{league} Wild Card #3",
+                    link: "/api/v1/teams/#{away_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -272,9 +272,9 @@ RSpec.describe Sync::Mlb::Matchups do
                     pct: ".000"
                   },
                   team: {
-                    id: 4614,
-                    name: "ALC1",
-                    link: "/api/v1/teams/4614"
+                    id: home_team_id,
+                    name: "#{league}C1",
+                    link: "/api/v1/teams/#{home_team_id}"
                   },
                   splitSquad: false,
                   seriesNumber: 1
@@ -282,10 +282,10 @@ RSpec.describe Sync::Mlb::Matchups do
               },
               venue: {
                 id: 3832,
-                name: "AL Stadium",
+                name: "#{league} Stadium",
                 link: "/api/v1/venues/3832"
               },
-              description: "AL Wild Card 'A' Game 3",
+              description: "#{league} Wild Card 'A' Game 3",
               seriesGameNumber: 3,
               seriesDescription: "Wild Card"
             }
@@ -294,31 +294,39 @@ RSpec.describe Sync::Mlb::Matchups do
       end
 
       it "returns correct round" do
-        expect(subject.send(:round)).to eq(1)
+        expect(subject.send(:round)).to eq(expected_round)
       end
 
       it "returns correct conference" do
-        expect(subject.send(:conference)).to eq("al")
+        expect(subject.send(:conference)).to eq(expected_conference)
       end
 
       it "returns correct number" do
-        expect(subject.send(:number)).to eq(1)
+        expect(subject.send(:number)).to eq(expected_number)
       end
 
       it "returns correct favorite_team_id" do
-        expect(subject.send(:favorite_team_id)).to eq(4614)
+        expect(subject.send(:favorite_team_id)).to eq(home_team_id)
       end
 
       it "returns correct favorite_tricode" do
-        expect(subject.send(:favorite_tricode)).to be_nil
+        tricode = subject.send(:favorite_tricode)
+        expect(tricode).to eq(expected_favorite_tricode)
+        if tricode
+          expect(Team.mlb_tricodes).to include(tricode)
+        end
       end
 
       it "returns correct underdog_team_id" do
-        expect(subject.send(:underdog_team_id)).to eq(4946)
+        expect(subject.send(:underdog_team_id)).to eq(away_team_id)
       end
 
       it "returns correct underdog_tricode" do
-        expect(subject.send(:underdog_tricode)).to be_nil
+        tricode = subject.send(:underdog_tricode)
+        expect(tricode).to eq(expected_underdog_tricode)
+        if tricode
+          expect(Team.mlb_tricodes).to include(tricode)
+        end
       end
 
       it "returns correct favorite_wins" do
@@ -331,6 +339,66 @@ RSpec.describe Sync::Mlb::Matchups do
 
       it "returns correct starts_at" do
         expect(subject.send(:starts_at)).to eq(Time.parse("2025-09-30T07:33:00Z"))
+      end
+    end
+
+    context "when series hasn't started and teams are unknown" do
+      context "AL Wild Card Series F_1 with unknown teams" do
+        it_behaves_like "series instance methods", "F_1", "F", "AL", 1, "al", 1, 4614, 4946, nil, nil
+      end
+
+      context "AL Wild Card Series F_2 with unknown teams" do
+        it_behaves_like "series instance methods", "F_2", "F", "AL", 1, "al", 2, 4614, 4946, nil, nil
+      end
+
+      context "NL Wild Card Series F_3 with unknown teams" do
+        it_behaves_like "series instance methods", "F_3", "F", "NL", 1, "nl", 1, 4614, 4946, nil, nil
+      end
+
+      context "NL Wild Card Series F_4 with unknown teams" do
+        it_behaves_like "series instance methods", "F_4", "F", "NL", 1, "nl", 2, 4614, 4946, nil, nil
+      end
+
+      context "AL Division Series D_1 with unknown teams" do
+        it_behaves_like "series instance methods", "D_1", "D", "AL", 2, "al", 1, 4614, 4946, nil, nil
+      end
+
+      context "AL Division Series D_2 with unknown teams" do
+        it_behaves_like "series instance methods", "D_2", "D", "AL", 2, "al", 2, 4614, 4946, nil, nil
+      end
+
+      context "NL Division Series D_3 with unknown teams" do
+        it_behaves_like "series instance methods", "D_3", "D", "NL", 2, "nl", 1, 4614, 4946, nil, nil
+      end
+
+      context "NL Division Series D_4 with unknown teams" do
+        it_behaves_like "series instance methods", "D_4", "D", "NL", 2, "nl", 2, 4614, 4946, nil, nil
+      end
+
+      context "AL Championship Series L_1 with unknown teams" do
+        it_behaves_like "series instance methods", "L_1", "L", "AL", 3, "al", 1, 4614, 4946, nil, nil
+      end
+
+      context "NL Championship Series L_2 with unknown teams" do
+        it_behaves_like "series instance methods", "L_2", "L", "NL", 3, "nl", 1, 4614, 4946, nil, nil
+      end
+
+      context "World Series W_1 with unknown teams" do
+        it_behaves_like "series instance methods", "W_1", "W", "WS", 4, "ws", 1, 4614, 4946, nil, nil
+      end
+    end
+
+    context "when series hasn't started and teams are known" do
+      context "AL Wild Card Series F_1 with known teams" do
+        it_behaves_like "series instance methods", "F_1", "F", "AL", 1, "al", 1, 142, 110, "min", "bal"
+      end
+
+      context "NL Wild Card Series F_3 with known teams" do
+        it_behaves_like "series instance methods", "F_3", "F", "NL", 1, "nl", 1, 119, 121, "lad", "nym"
+      end
+
+      context "World Series W_1 with known teams" do
+        it_behaves_like "series instance methods", "W_1", "W", "WS", 4, "ws", 1, 109, 133, "ari", "oak"
       end
     end
   end

--- a/spec/lib/sync/mlb/matchups_spec.rb
+++ b/spec/lib/sync/mlb/matchups_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Sync::Mlb::Matchups do
+  describe "::run" do
+    subject { described_class.run(year) }
+
+    let(:year) { rand(2020..2025) }
+    let(:teams_data) do
+      {
+        teams: teams
+      }
+    end
+    let(:teams) do
+      [
+        {
+          id: 1,
+          abbreviation: "LAD"
+        },
+        {
+          id: 2,
+          abbreviation: "NYY"
+        }
+      ]
+    end
+    let(:postseason_data) do
+      {
+        series: series
+      }
+    end
+    let(:series) do
+      [
+        {
+          data: 1
+        },
+        {
+          data: 2
+        }
+      ]
+    end
+    let(:team_ids_to_abbreviations) do
+      {
+        1 => "lad",
+        2 => "nyy"
+      }
+    end
+
+    it "syncs all the matchups from the fetched postseason data" do
+      expect(Sync::Mlb::Client).to receive(:fetch_teams).and_return(teams_data)
+      expect(Sync::Mlb::Client).to receive(:fetch_postseason).with(year).and_return(postseason_data)
+      series.each do |s|
+        expect(described_class).to receive(:sync_matchup).with(year, s, team_ids_to_abbreviations)
+      end
+
+      subject
+    end
+  end
+
+  describe "::sync_matchup" do
+    subject { described_class.sync_matchup(year, series_data, team_ids_to_abbreviations) }
+
+    let(:year) { rand(2020..2025) }
+    let(:series_data) { {data: SecureRandom.hex} }
+    let(:team_ids_to_abbreviations) { {1 => "lad", 2 => "nyy"} }
+
+    it "syncs with an instance" do
+      expect_any_instance_of(described_class).to receive(:sync_matchup) do |instance|
+        expect(instance.instance_variable_get(:@year)).to eql(year)
+        expect(instance.instance_variable_get(:@series_data)).to eql(series_data)
+        expect(instance.instance_variable_get(:@team_ids_to_abbreviations)).to eql(team_ids_to_abbreviations)
+      end
+      subject
+    end
+  end
+end

--- a/spec/lib/sync/mlb/matchups_spec.rb
+++ b/spec/lib/sync/mlb/matchups_spec.rb
@@ -71,4 +71,267 @@ RSpec.describe Sync::Mlb::Matchups do
       subject
     end
   end
+
+  describe "#instance_methods" do
+    subject { instance }
+    let(:instance) { described_class.new(year, series_data, team_ids_to_abbreviations) }
+    let(:year) { 2025 }
+    let(:team_ids_to_abbreviations) do
+      {
+        133 => "ath",
+        134 => "pit",
+        135 => "sd",
+        136 => "sea",
+        137 => "sf",
+        138 => "stl",
+        139 => "tb",
+        140 => "tex",
+        141 => "tor",
+        142 => "min",
+        143 => "phi",
+        144 => "atl",
+        145 => "cws",
+        146 => "mia",
+        147 => "nyy",
+        158 => "mil",
+        108 => "laa",
+        109 => "az",
+        110 => "bal",
+        111 => "bos",
+        112 => "chc",
+        113 => "cin",
+        114 => "cle",
+        115 => "col",
+        116 => "det",
+        117 => "hou",
+        118 => "kc",
+        119 => "lad",
+        120 => "wsh",
+        121 => "nym"
+      }
+    end
+
+    context "when series hasn't started and teams are unknown" do
+      let(:series_data) do
+        {
+          series: {
+            id: "F_1",
+            sortNumber: 1,
+            isDefault: true,
+            gameType: "F"
+          },
+          totalItems: 3,
+          totalGames: 3,
+          totalGamesInProgress: 0,
+          games: [
+            {
+              gamePk: 813072,
+              gameGuid: "302be26b-38e4-4555-ad7c-b94b17ebd0eb",
+              link: "/api/v1.1/game/813072/feed/live",
+              gameType: "F",
+              season: "2025",
+              gameDate: "2025-09-30T07:33:00Z",
+              officialDate: "2025-09-30",
+              status: {
+                abstractGameState: "Preview",
+                codedGameState: "S",
+                detailedState: "Scheduled",
+                statusCode: "S",
+                startTimeTBD: true,
+                abstractGameCode: "P"
+              },
+              teams: {
+                away: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4946,
+                    name: "AL Wild Card #3",
+                    link: "/api/v1/teams/4946"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                },
+                home: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4614,
+                    name: "ALC1",
+                    link: "/api/v1/teams/4614"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                }
+              },
+              venue: {
+                id: 3832,
+                name: "AL Stadium",
+                link: "/api/v1/venues/3832"
+              },
+              description: "AL Wild Card 'A' Game 1",
+              seriesGameNumber: 1,
+              seriesDescription: "Wild Card"
+            },
+            {
+              gamePk: 813071,
+              gameGuid: "fca403df-ecba-4340-b893-370ece3b6f7d",
+              link: "/api/v1.1/game/813071/feed/live",
+              gameType: "F",
+              season: "2025",
+              gameDate: "2025-10-01T07:33:00Z",
+              officialDate: "2025-10-01",
+              status: {
+                abstractGameState: "Preview",
+                codedGameState: "S",
+                detailedState: "Scheduled",
+                statusCode: "S",
+                startTimeTBD: true,
+                abstractGameCode: "P"
+              },
+              teams: {
+                away: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4946,
+                    name: "AL Wild Card #3",
+                    link: "/api/v1/teams/4946"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                },
+                home: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4614,
+                    name: "ALC1",
+                    link: "/api/v1/teams/4614"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                }
+              },
+              venue: {
+                id: 3832,
+                name: "AL Stadium",
+                link: "/api/v1/venues/3832"
+              },
+              description: "AL Wild Card 'A' Game 2",
+              seriesGameNumber: 2,
+              seriesDescription: "Wild Card"
+            },
+            {
+              gamePk: 813073,
+              gameGuid: "d69c1633-4f00-4b6d-b65d-55d29989a79c",
+              link: "/api/v1.1/game/813073/feed/live",
+              gameType: "F",
+              season: "2025",
+              gameDate: "2025-10-02T07:33:00Z",
+              officialDate: "2025-10-02",
+              status: {
+                abstractGameState: "Preview",
+                codedGameState: "S",
+                detailedState: "Scheduled",
+                statusCode: "S",
+                startTimeTBD: true,
+                abstractGameCode: "P"
+              },
+              teams: {
+                away: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4946,
+                    name: "AL Wild Card #3",
+                    link: "/api/v1/teams/4946"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                },
+                home: {
+                  leagueRecord: {
+                    wins: 0,
+                    losses: 0,
+                    pct: ".000"
+                  },
+                  team: {
+                    id: 4614,
+                    name: "ALC1",
+                    link: "/api/v1/teams/4614"
+                  },
+                  splitSquad: false,
+                  seriesNumber: 1
+                }
+              },
+              venue: {
+                id: 3832,
+                name: "AL Stadium",
+                link: "/api/v1/venues/3832"
+              },
+              description: "AL Wild Card 'A' Game 3",
+              seriesGameNumber: 3,
+              seriesDescription: "Wild Card"
+            }
+          ]
+        }
+      end
+
+      it "returns correct round" do
+        expect(subject.send(:round)).to eq(1)
+      end
+
+      it "returns correct conference" do
+        expect(subject.send(:conference)).to eq("al")
+      end
+
+      it "returns correct number" do
+        expect(subject.send(:number)).to eq(1)
+      end
+
+      it "returns correct favorite_team_id" do
+        expect(subject.send(:favorite_team_id)).to eq(4614)
+      end
+
+      it "returns correct favorite_tricode" do
+        expect(subject.send(:favorite_tricode)).to be_nil
+      end
+
+      it "returns correct underdog_team_id" do
+        expect(subject.send(:underdog_team_id)).to eq(4946)
+      end
+
+      it "returns correct underdog_tricode" do
+        expect(subject.send(:underdog_tricode)).to be_nil
+      end
+
+      it "returns correct favorite_wins" do
+        expect(subject.send(:favorite_wins)).to eq(0)
+      end
+
+      it "returns correct underdog_wins" do
+        expect(subject.send(:underdog_wins)).to eq(0)
+      end
+
+      it "returns correct starts_at" do
+        expect(subject.send(:starts_at)).to eq(Time.parse("2025-09-30T07:33:00Z"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
The overall structure and flow of syncing is the same as we had for the NBA, which has now been extracted into `Sync::MatchupBase`. The NBA/MLB classes now just contain the specifics of fetching and parsing the series data for each league.

Resolves #143 