### PR TITLE
Fix round headers on scroll

### DIFF
--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   user-select: none;
   position: relative;
+  z-index: 0;
 
   &:hover {
     background-color: rgba(0, 0, 0, 0.05);
@@ -38,4 +39,8 @@
     border-bottom: 6px solid currentColor;
     opacity: 1;
   }
+}
+
+.table-name-col {
+  z-index: 1;
 }


### PR DESCRIPTION
The `span` added to `matchup_title` for sorting is causing the matchup title heading to go on top of the name heading as it scrolls to the left.