### PR TITLE
Design refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+**Server** (requires rbenv with Ruby 3.1.7 and `eval "$(rbenv init -)"`):
+```bash
+bin/rails server                        # start Rails on localhost:3000
+bin/webpack-dev-server                  # start JS/CSS asset pipeline (required in dev)
+```
+
+**Tests:**
+```bash
+bundle exec rspec                       # full suite
+bundle exec rspec spec/models/pick_spec.rb                  # single file
+bundle exec rspec spec/models/pick_spec.rb:42               # single example
+```
+
+**Linting:**
+```bash
+bundle exec standardrb                  # Ruby linter (StandardRB, based on RuboCop)
+bundle exec standardrb --fix            # auto-fix
+```
+
+**Database:**
+```bash
+rails db:create db:migrate db:seed
+heroku pg:pull DATABASE_URL nba_playoff_pool_development --app sports-pals  # pull prod data
+```
+
+**Deployment:** Heroku app is `sports-pals`. Push to Heroku or merge to main to deploy.
+
+## Architecture
+
+### Domain model
+
+The app is a playoff prediction pool. Users submit **picks** before each series starts. A pick records which team wins and in how many games. Points are awarded based on a **scoring grid** (`app/lib/scoring_grid.rb`) that rewards correct predictions more heavily the harder the outcome is to predict.
+
+Key models:
+- `Matchup` — one playoff series (favorite + underdog tricodes, win counts, round/conference/year/sport). Identified by tricode enums backed by `Team`.
+- `Pick` — a user's prediction for one matchup (winner_is_favorite boolean + num_games).
+- `User` — Devise-backed, has username + email + admin flag.
+
+`CurrentSeason` (`app/lib/current_season.rb`) is a module constant that sets the active sport/year. **Update `SPORT` and `YEAR` here to switch seasons.**
+
+### Scoring pipeline
+
+`app/lib/user_scores/` contains the scoring logic:
+- `Base` — shared `build` class method that instantiates one score object per user and assigns ranks.
+- `Round` — per-user scores for one playoff round. Holds `picks_by_matchup_id`, computes `min_total` (points already locked in) and `max_total` (best possible outcome).
+- `Total` — aggregates `Round` scores across all rounds for the overall standings.
+- `MatchupBase` — per-pick scoring, computing `min_points`, `max_points`, `potential_points`, and `scoring_index` (used for sorting).
+
+`StandingsController#index` builds `@data` (array of `UserScores::Total`) and `@rounds_data` (array of per-round hashes). Both are passed to views. All matchup objects are marked `readonly!` to prevent accidental DB writes during simulation.
+
+### Simulation
+
+Users can simulate unfinished series outcomes via URL params (`sim[]=<matchup_id>:<outcome>`). The controller applies simulations in-memory on the readonly matchup objects before scoring — no DB writes occur.
+
+### Team data
+
+`app/lib/team.rb` defines all NBA and MLB teams as `Team` instances (tricode, city, name, nickname). `Matchup` stores tricodes as enums and exposes `favorite` / `underdog` as `Team` objects. `NBA_COLORS` maps tricodes to `{primary:, secondary:}` hex pairs used for progress bar styling.
+
+### Frontend
+
+- Bootstrap 5.2 + Webpacker (webpack 4). JS entry: `app/javascript/packs/application.js`.
+- Custom stylesheets in `app/assets/stylesheets/` (Sprockets pipeline).
+- Dark mode is toggled via `html.dark-mode` CSS class, persisted in localStorage.
+- Sortable table columns and simulation dropdowns are wired in `application.js` via `turbolinks:load`.
+
+### PlayoffStructure / ScoringGrid
+
+`app/lib/playoff_structure.rb` and `app/lib/scoring_grid.rb` define sport-specific constants (rounds, games per round, scoring tables). These are indexed by `Matchup` objects.
+
+### Admin / sync
+
+`rails_admin` is mounted at `/admin` for admin users. `app/lib/sync/` contains scripts for syncing matchup data from external sources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,9 @@ Users can simulate unfinished series outcomes via URL params (`sim[]=<matchup_id
 
 ### Frontend
 
-- Bootstrap 5.2 + Webpacker (webpack 4). JS entry: `app/javascript/packs/application.js`.
+- Bootstrap 5.3 + Webpacker (webpack 4). JS entry: `app/javascript/packs/application.js`.
 - Custom stylesheets in `app/assets/stylesheets/` (Sprockets pipeline).
-- Dark mode is toggled via `html.dark-mode` CSS class, persisted in localStorage.
+- Dark mode uses Bootstrap 5.3's `data-bs-theme="dark"` attribute on `<html>`, persisted in localStorage under key `theme`.
 - Sortable table columns and simulation dropdowns are wired in `application.js` via `turbolinks:load`.
 
 ### PlayoffStructure / ScoringGrid

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -43,3 +43,8 @@ th:nth-child(2), td:nth-child(2) {
   --bs-table-bg: #fff;
   background-color: #fff !important;
 }
+
+.table.table-white tbody td,
+.table.table-white tbody th {
+  border-bottom-width: 0;
+}

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -1,65 +1,10 @@
-html.dark-mode {
+// Bootstrap 5.3 handles most dark mode styles via data-bs-theme="dark".
+// This file contains only app-specific overrides.
+
+[data-bs-theme="dark"] {
+  // Match body bg to table bg so tables don't look like floating boxes
   body {
     background-color: #2b3035;
-    color: #dee2e6;
-  }
-
-  .navbar {
-    background-color: #343a40 !important;
-    border-bottom: 1px solid #495057;
-
-    .navbar-brand {
-      color: #dee2e6 !important;
-    }
-
-    .nav-link {
-      color: #adb5bd !important;
-
-      &:hover, &.active {
-        color: #fff !important;
-      }
-    }
-
-    .navbar-toggler {
-      border-color: #6c757d;
-    }
-
-    #dark-mode-toggle {
-      color: #adb5bd;
-
-      &:hover {
-        color: #fff;
-        background-color: #495057;
-      }
-    }
-
-    .dropdown-menu {
-      background-color: #343a40;
-      border-color: #495057;
-
-      .dropdown-item {
-        color: #dee2e6;
-
-        &:hover {
-          background-color: #495057;
-          color: #fff;
-        }
-      }
-
-      .dropdown-divider {
-        border-color: #495057;
-      }
-    }
-  }
-
-  .table {
-    --bs-table-color: #dee2e6;
-    --bs-table-bg: #2b3035;
-    --bs-table-border-color: #495057;
-    --bs-table-striped-bg: #323840;
-    --bs-table-hover-bg: #373e46;
-    --bs-table-hover-color: #dee2e6;
-    --bs-table-striped-color: #dee2e6;
   }
 
   .table.table-white {
@@ -68,27 +13,20 @@ html.dark-mode {
   }
 
   // Sticky column needs explicit bg to avoid bleed-through
-  th:nth-child(2), td:nth-child(2) {
+  .table-name-col {
     background-color: #2b3035;
   }
 
-  .alert-success {
-    background-color: #0f5132;
-    border-color: #0a3622;
-    color: #75b798;
+  // Keep name text visible on row hover
+  .table-name-col span {
+    color: var(--bs-body-color);
+
+    &:hover {
+      color: #fff;
+    }
   }
 
-  .alert-danger {
-    background-color: #842029;
-    border-color: #6a1a21;
-    color: #ea868f;
-  }
-
-  .btn-close {
-    filter: invert(1) grayscale(100%) brightness(200%);
-  }
-
-  // Teams with dark primary colors need inverted treatment in dark mode
+  // Team-specific progress bar overrides for teams with problematic dark colors
   .progress[data-tricode="lal"] {
     .progress-bar {
       background-color: #552583 !important;
@@ -99,14 +37,6 @@ html.dark-mode {
     .progress-bar {
       background-color: #DEDEDE !important;
       color: #000 !important;
-    }
-  }
-
-  .table-name-col span {
-    color: #dee2e6;
-
-    &:hover {
-      color: #fff;
     }
   }
 }

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -58,6 +58,7 @@ html.dark-mode {
     --bs-table-border-color: #495057;
     --bs-table-striped-bg: #323840;
     --bs-table-hover-bg: #373e46;
+    --bs-table-hover-color: #dee2e6;
     --bs-table-striped-color: #dee2e6;
   }
 
@@ -85,6 +86,30 @@ html.dark-mode {
 
   .btn-close {
     filter: invert(1) grayscale(100%) brightness(200%);
+  }
+
+  // Teams with dark primary colors need inverted treatment in dark mode
+  td[data-tricode="lal"],
+  span[data-tricode="lal"] {
+    color: #FDB927 !important;
+  }
+
+  .progress[data-tricode="lal"] {
+    .progress-bar {
+      background-color: #552583 !important;
+    }
+  }
+
+  td[data-tricode="sas"],
+  span[data-tricode="sas"] {
+    color: #DEDEDE !important;
+  }
+
+  .progress[data-tricode="sas"] {
+    .progress-bar {
+      background-color: #DEDEDE !important;
+      color: #000 !important;
+    }
   }
 
   .table-name-col span {

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -5,11 +5,15 @@
   // Match body bg to table bg so tables don't look like floating boxes
   body {
     background-color: #2b3035;
+    color: #dee2e6;
   }
 
   .table.table-white {
     --bs-table-bg: #2b3035 !important;
+    --bs-table-color: #dee2e6 !important;
+    --bs-table-hover-color: #dee2e6 !important;
     background-color: #2b3035 !important;
+    color: #dee2e6 !important;
   }
 
   // Sticky column needs explicit bg to avoid bleed-through
@@ -19,7 +23,7 @@
 
   // Keep name text visible on row hover
   .table-name-col span {
-    color: var(--bs-body-color);
+    color: #dee2e6;
 
     &:hover {
       color: #fff;

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -89,20 +89,10 @@ html.dark-mode {
   }
 
   // Teams with dark primary colors need inverted treatment in dark mode
-  td[data-tricode="lal"],
-  span[data-tricode="lal"] {
-    color: #FDB927 !important;
-  }
-
   .progress[data-tricode="lal"] {
     .progress-bar {
       background-color: #552583 !important;
     }
-  }
-
-  td[data-tricode="sas"],
-  span[data-tricode="sas"] {
-    color: #DEDEDE !important;
   }
 
   .progress[data-tricode="sas"] {

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -1,15 +1,3 @@
-.dark-mode-toggle {
-  font-size: 1.1rem;
-  line-height: 1;
-  padding: 0.2rem 0.4rem;
-  border: none;
-  background: none;
-
-  &:hover {
-    opacity: 0.75;
-  }
-}
-
 html.dark-mode {
   body {
     background-color: #212529;
@@ -34,6 +22,15 @@ html.dark-mode {
 
     .navbar-toggler {
       border-color: #6c757d;
+    }
+
+    #dark-mode-toggle {
+      color: #adb5bd;
+
+      &:hover {
+        color: #fff;
+        background-color: #495057;
+      }
     }
 
     .dropdown-menu {

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -1,0 +1,92 @@
+.dark-mode-toggle {
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.2rem 0.4rem;
+  border: none;
+  background: none;
+
+  &:hover {
+    opacity: 0.75;
+  }
+}
+
+html.dark-mode {
+  body {
+    background-color: #212529;
+    color: #dee2e6;
+  }
+
+  .navbar {
+    background-color: #343a40 !important;
+    border-bottom: 1px solid #495057;
+
+    .navbar-brand {
+      color: #dee2e6 !important;
+    }
+
+    .nav-link {
+      color: #adb5bd !important;
+
+      &:hover, &.active {
+        color: #fff !important;
+      }
+    }
+
+    .navbar-toggler {
+      border-color: #6c757d;
+    }
+
+    .dropdown-menu {
+      background-color: #343a40;
+      border-color: #495057;
+
+      .dropdown-item {
+        color: #dee2e6;
+
+        &:hover {
+          background-color: #495057;
+          color: #fff;
+        }
+      }
+
+      .dropdown-divider {
+        border-color: #495057;
+      }
+    }
+  }
+
+  .table {
+    --bs-table-color: #dee2e6;
+    --bs-table-bg: #2b3035;
+    --bs-table-border-color: #495057;
+    --bs-table-striped-bg: #323840;
+    --bs-table-hover-bg: #373e46;
+    --bs-table-striped-color: #dee2e6;
+  }
+
+  .table.table-white {
+    --bs-table-bg: #2b3035 !important;
+    background-color: #2b3035 !important;
+  }
+
+  // Sticky column needs explicit bg to avoid bleed-through
+  th:nth-child(2), td:nth-child(2) {
+    background-color: #2b3035;
+  }
+
+  .alert-success {
+    background-color: #0f5132;
+    border-color: #0a3622;
+    color: #75b798;
+  }
+
+  .alert-danger {
+    background-color: #842029;
+    border-color: #6a1a21;
+    color: #ea868f;
+  }
+
+  .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+  }
+}

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -30,17 +30,4 @@
     }
   }
 
-  // Team-specific progress bar overrides for teams with problematic dark colors
-  .progress[data-tricode="lal"] {
-    .progress-bar {
-      background-color: #552583 !important;
-    }
-  }
-
-  .progress[data-tricode="sas"] {
-    .progress-bar {
-      background-color: #DEDEDE !important;
-      color: #000 !important;
-    }
-  }
 }

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -1,6 +1,6 @@
 html.dark-mode {
   body {
-    background-color: #212529;
+    background-color: #2b3035;
     color: #dee2e6;
   }
 

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -86,4 +86,12 @@ html.dark-mode {
   .btn-close {
     filter: invert(1) grayscale(100%) brightness(200%);
   }
+
+  .table-name-col span {
+    color: #dee2e6;
+
+    &:hover {
+      color: #fff;
+    }
+  }
 }

--- a/app/assets/stylesheets/round.scss
+++ b/app/assets/stylesheets/round.scss
@@ -1,5 +1,4 @@
 .simulation-select {
-  border-radius: 999px;
   border: 1px solid rgba(0, 0, 0, 0.15);
   background-color: rgba(255, 255, 255, 0.85);
   font-size: 0.85rem !important;

--- a/app/assets/stylesheets/round.scss
+++ b/app/assets/stylesheets/round.scss
@@ -1,0 +1,42 @@
+.simulation-select {
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background-color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem !important;
+  padding: 0.25rem 1.85rem 0.25rem 0.75rem;
+  font-weight: 500;
+  color: #495057;
+  width: 10rem !important;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+
+  &:hover {
+    border-color: rgba(0, 0, 0, 0.3);
+    background-color: #fff;
+  }
+
+  &:focus {
+    border-color: #86b7fe;
+    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.2);
+    outline: none;
+  }
+}
+
+html.dark-mode {
+  .simulation-select {
+    background-color: rgba(255, 255, 255, 0.07);
+    border-color: rgba(255, 255, 255, 0.15);
+    color: #dee2e6;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23dee2e6' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.3);
+      background-color: rgba(255, 255, 255, 0.12);
+    }
+
+    &:focus {
+      border-color: #86b7fe;
+      box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.2);
+    }
+  }
+}

--- a/app/assets/stylesheets/round.scss
+++ b/app/assets/stylesheets/round.scss
@@ -21,7 +21,7 @@
   }
 }
 
-html.dark-mode {
+[data-bs-theme="dark"] {
   .simulation-select {
     background-color: rgba(255, 255, 255, 0.07);
     border-color: rgba(255, 255, 255, 0.15);

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -72,3 +72,13 @@
 .table-name-col {
   z-index: 1;
 }
+
+.table.table-white th,
+.table.table-white td {
+  padding-inline: 0.5rem;
+}
+
+.table.table-white tfoot td,
+.table.table-white tfoot th {
+  border-bottom-width: 0;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,15 +22,16 @@ document.addEventListener("turbolinks:load", () => {
     if (toggle) {
         const sun = document.getElementById('dark-mode-sun');
         const moon = document.getElementById('dark-mode-moon');
-        const isDark = () => document.documentElement.classList.contains('dark-mode');
+        const isDark = () => document.documentElement.getAttribute('data-bs-theme') === 'dark';
         const updateIcons = () => {
             sun.style.display = isDark() ? 'block' : 'none';
             moon.style.display = isDark() ? 'none' : 'block';
         };
         updateIcons();
         toggle.addEventListener('click', () => {
-            document.documentElement.classList.toggle('dark-mode');
-            localStorage.setItem('darkMode', isDark());
+            const theme = isDark() ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            localStorage.setItem('theme', theme);
             updateIcons();
         });
     }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,6 +18,18 @@ Turbolinks.start()
 ActiveStorage.start()
 
 document.addEventListener("turbolinks:load", () => {
+    const toggle = document.getElementById('dark-mode-toggle');
+    if (toggle) {
+        const isDark = () => document.documentElement.classList.contains('dark-mode');
+        toggle.textContent = isDark() ? '☀️' : '🌙';
+        toggle.addEventListener('click', () => {
+            document.documentElement.classList.toggle('dark-mode');
+            const dark = isDark();
+            toggle.textContent = dark ? '☀️' : '🌙';
+            localStorage.setItem('darkMode', dark);
+        });
+    }
+
     // Both of these are from the Bootstrap 5 docs
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     var tooltipList = tooltipTriggerList.map(function(tooltipTriggerEl) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,40 @@ Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
+function getColorLuminance(hex) {
+    if (!hex) return 128;
+    const h = hex.replace('#', '');
+    if (h.length < 6) return 128;
+    const r = parseInt(h.substring(0, 2), 16);
+    const g = parseInt(h.substring(2, 4), 16);
+    const b = parseInt(h.substring(4, 6), 16);
+    return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+function pickTeamColor(primary, secondary, isDark) {
+    if (!secondary) return primary;
+    const lumP = getColorLuminance(primary);
+    if (isDark && lumP < 80) {
+        const lumS = getColorLuminance(secondary);
+        return lumS > lumP ? secondary : primary;
+    }
+    if (!isDark && lumP > 200) {
+        const lumS = getColorLuminance(secondary);
+        return lumS < lumP ? secondary : primary;
+    }
+    return primary;
+}
+
+function applyTeamColors() {
+    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
+    document.querySelectorAll('.progress[data-primary-color]').forEach(bar => {
+        const color = pickTeamColor(bar.dataset.primaryColor, bar.dataset.secondaryColor, isDark);
+        bar.querySelectorAll('.progress-bar').forEach(segment => {
+            segment.style.backgroundColor = color;
+        });
+    });
+}
+
 document.addEventListener("turbolinks:load", () => {
     const toggle = document.getElementById('dark-mode-toggle');
     if (toggle) {
@@ -33,8 +67,11 @@ document.addEventListener("turbolinks:load", () => {
             document.documentElement.setAttribute('data-bs-theme', theme);
             localStorage.setItem('theme', theme);
             updateIcons();
+            applyTeamColors();
         });
     }
+
+    applyTeamColors();
 
     // Both of these are from the Bootstrap 5 docs
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,13 +20,18 @@ ActiveStorage.start()
 document.addEventListener("turbolinks:load", () => {
     const toggle = document.getElementById('dark-mode-toggle');
     if (toggle) {
+        const sun = document.getElementById('dark-mode-sun');
+        const moon = document.getElementById('dark-mode-moon');
         const isDark = () => document.documentElement.classList.contains('dark-mode');
-        toggle.textContent = isDark() ? '☀️' : '🌙';
+        const updateIcons = () => {
+            sun.style.display = isDark() ? 'block' : 'none';
+            moon.style.display = isDark() ? 'none' : 'block';
+        };
+        updateIcons();
         toggle.addEventListener('click', () => {
             document.documentElement.classList.toggle('dark-mode');
-            const dark = isDark();
-            toggle.textContent = dark ? '☀️' : '🌙';
-            localStorage.setItem('darkMode', dark);
+            localStorage.setItem('darkMode', isDark());
+            updateIcons();
         });
     }
 

--- a/app/lib/team.rb
+++ b/app/lib/team.rb
@@ -1,11 +1,13 @@
 class Team
-  attr_reader :tricode, :city, :name, :nickname
+  attr_reader :tricode, :city, :name, :nickname, :primary_color, :secondary_color
 
-  def initialize(tricode, city, name, nickname)
+  def initialize(tricode, city, name, nickname = nil, primary_color: nil, secondary_color: nil)
     @tricode = tricode
     @city = city
     @name = name
     @nickname = nickname
+    @primary_color = primary_color
+    @secondary_color = secondary_color
   end
 
   def full_name
@@ -15,6 +17,43 @@ class Team
   def short_name
     nickname || name
   end
+
+  def colors
+    {primary: primary_color, secondary: secondary_color}
+  end
+
+  NBA_COLORS = {
+    atl: {primary: "#E03A3E", secondary: "#C1D32F"},
+    bkn: {primary: "#000000", secondary: "#AAAAAA"},
+    bos: {primary: "#007A33", secondary: "#BA9653"},
+    cha: {primary: "#1D1160", secondary: "#00788C"},
+    chi: {primary: "#CE1141", secondary: "#000000"},
+    cle: {primary: "#FDBB30", secondary: "#C8004A"},
+    dal: {primary: "#00538C", secondary: "#002B5E"},
+    den: {primary: "#FEC524", secondary: "#2E86C1"},
+    det: {primary: "#C8102E", secondary: "#006BB6"},
+    gsw: {primary: "#1D428A", secondary: "#FFC72C"},
+    hou: {primary: "#CE1141", secondary: "#000000"},
+    ind: {primary: "#002D62", secondary: "#FDBB30"},
+    lac: {primary: "#C8102E", secondary: "#1D428A"},
+    lal: {primary: "#552583", secondary: "#FDB927"},
+    mem: {primary: "#5D76A9", secondary: "#12173F"},
+    mia: {primary: "#98002E", secondary: "#F9A01B"},
+    mil: {primary: "#00471B", secondary: "#EEE1C6"},
+    min: {primary: "#2E9FD8", secondary: "#236192"},
+    nop: {primary: "#0C2340", secondary: "#C8102E"},
+    nyk: {primary: "#006BB6", secondary: "#F58426"},
+    okc: {primary: "#007AC1", secondary: "#EF3B24"},
+    orl: {primary: "#0077C0", secondary: "#C4CED4"},
+    phi: {primary: "#006BB6", secondary: "#ED174C"},
+    phx: {primary: "#1D1160", secondary: "#E56020"},
+    por: {primary: "#E03A3E", secondary: "#000000"},
+    sac: {primary: "#5A2D81", secondary: "#63727A"},
+    sas: {primary: "#000000", secondary: "#C4CED4"},
+    tor: {primary: "#CE1141", secondary: "#000000"},
+    uta: {primary: "#002B5C", secondary: "#00471B"},
+    was: {primary: "#002B5C", secondary: "#E31837"}
+  }.freeze
 
   NBA_TEAMS = [
     [:atl, "Atlanta", "Hawks"],
@@ -47,8 +86,10 @@ class Team
     [:tor, "Toronto", "Raptors"],
     [:uta, "Utah", "Jazz"],
     [:was, "Washington", "Wizards"]
-  ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
-    .with_indifferent_access
+  ].to_h do |tc, c, n, nn|
+    colors = NBA_COLORS[tc] || {}
+    [tc, Team.new(tc, c, n, nn, primary_color: colors[:primary], secondary_color: colors[:secondary])]
+  end.with_indifferent_access
 
   MLB_TEAMS = [
     [:ari, "Arizona", "Diamondbacks"],
@@ -84,44 +125,7 @@ class Team
   ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
     .with_indifferent_access
 
-  NBA_COLORS = {
-    atl: {primary: "#E03A3E", secondary: "#C1D32F"},
-    bkn: {primary: "#000000", secondary: "#AAAAAA"},
-    bos: {primary: "#007A33", secondary: "#BA9653"},
-    cha: {primary: "#1D1160", secondary: "#00788C"},
-    chi: {primary: "#CE1141", secondary: "#000000"},
-    cle: {primary: "#FDBB30", secondary: "#C8004A"},
-    dal: {primary: "#00538C", secondary: "#002B5E"},
-    den: {primary: "#FEC524", secondary: "#2E86C1"},
-    det: {primary: "#C8102E", secondary: "#006BB6"},
-    gsw: {primary: "#1D428A", secondary: "#FFC72C"},
-    hou: {primary: "#CE1141", secondary: "#000000"},
-    ind: {primary: "#002D62", secondary: "#FDBB30"},
-    lac: {primary: "#C8102E", secondary: "#1D428A"},
-    lal: {primary: "#552583", secondary: "#FDB927"},
-    mem: {primary: "#5D76A9", secondary: "#12173F"},
-    mia: {primary: "#98002E", secondary: "#F9A01B"},
-    mil: {primary: "#00471B", secondary: "#EEE1C6"},
-    min: {primary: "#2E9FD8", secondary: "#236192"},
-    nop: {primary: "#0C2340", secondary: "#C8102E"},
-    nyk: {primary: "#006BB6", secondary: "#F58426"},
-    okc: {primary: "#007AC1", secondary: "#EF3B24"},
-    orl: {primary: "#0077C0", secondary: "#C4CED4"},
-    phi: {primary: "#006BB6", secondary: "#ED174C"},
-    phx: {primary: "#1D1160", secondary: "#E56020"},
-    por: {primary: "#E03A3E", secondary: "#000000"},
-    sac: {primary: "#5A2D81", secondary: "#63727A"},
-    sas: {primary: "#000000", secondary: "#C4CED4"},
-    tor: {primary: "#CE1141", secondary: "#000000"},
-    uta: {primary: "#002B5C", secondary: "#00471B"},
-    was: {primary: "#002B5C", secondary: "#E31837"}
-  }.with_indifferent_access
-
   class << self
-    def nba_colors(tricode)
-      NBA_COLORS[tricode]
-    end
-
     def nba_tricodes
       NBA_TEAMS.keys
     end

--- a/app/lib/team.rb
+++ b/app/lib/team.rb
@@ -84,7 +84,44 @@ class Team
   ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
     .with_indifferent_access
 
+  NBA_COLORS = {
+    atl: {primary: "#E03A3E", secondary: "#C1D32F"},
+    bkn: {primary: "#000000", secondary: "#AAAAAA"},
+    bos: {primary: "#007A33", secondary: "#BA9653"},
+    cha: {primary: "#1D1160", secondary: "#00788C"},
+    chi: {primary: "#CE1141", secondary: "#000000"},
+    cle: {primary: "#FDBB30", secondary: "#C8004A"},
+    dal: {primary: "#00538C", secondary: "#002B5E"},
+    den: {primary: "#FEC524", secondary: "#2E86C1"},
+    det: {primary: "#C8102E", secondary: "#006BB6"},
+    gsw: {primary: "#1D428A", secondary: "#FFC72C"},
+    hou: {primary: "#CE1141", secondary: "#000000"},
+    ind: {primary: "#002D62", secondary: "#FDBB30"},
+    lac: {primary: "#C8102E", secondary: "#1D428A"},
+    lal: {primary: "#552583", secondary: "#FDB927"},
+    mem: {primary: "#5D76A9", secondary: "#12173F"},
+    mia: {primary: "#98002E", secondary: "#F9A01B"},
+    mil: {primary: "#00471B", secondary: "#EEE1C6"},
+    min: {primary: "#2E9FD8", secondary: "#236192"},
+    nop: {primary: "#0C2340", secondary: "#C8102E"},
+    nyk: {primary: "#006BB6", secondary: "#F58426"},
+    okc: {primary: "#007AC1", secondary: "#EF3B24"},
+    orl: {primary: "#0077C0", secondary: "#C4CED4"},
+    phi: {primary: "#006BB6", secondary: "#ED174C"},
+    phx: {primary: "#1D1160", secondary: "#E56020"},
+    por: {primary: "#E03A3E", secondary: "#000000"},
+    sac: {primary: "#5A2D81", secondary: "#63727A"},
+    sas: {primary: "#000000", secondary: "#C4CED4"},
+    tor: {primary: "#CE1141", secondary: "#000000"},
+    uta: {primary: "#002B5C", secondary: "#00471B"},
+    was: {primary: "#002B5C", secondary: "#E31837"}
+  }.with_indifferent_access
+
   class << self
+    def nba_colors(tricode)
+      NBA_COLORS[tricode]
+    end
+
     def nba_tricodes
       NBA_TEAMS.keys
     end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,22 +1,6 @@
-<nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
+<nav class="navbar navbar-expand-md mb-4">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Sports Pals</a>
-    <button id="dark-mode-toggle" class="btn btn-sm btn-outline-secondary border-0 ms-2" aria-label="Toggle dark mode">
-      <svg id="dark-mode-sun" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="5"></circle>
-        <line x1="12" y1="1" x2="12" y2="3"></line>
-        <line x1="12" y1="21" x2="12" y2="23"></line>
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-        <line x1="1" y1="12" x2="3" y2="12"></line>
-        <line x1="21" y1="12" x2="23" y2="12"></line>
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-      </svg>
-      <svg id="dark-mode-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-      </svg>
-    </button>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -52,6 +36,24 @@
         <% end %>
         <%= render 'devise/menu/registration_items' %>
         <%= render 'devise/menu/login_items' %>
+        <li class="nav-item">
+          <button id="dark-mode-toggle" class="btn btn-sm btn-outline-secondary border-0 nav-link" aria-label="Toggle dark mode">
+            <svg id="dark-mode-sun" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="5"></circle>
+              <line x1="12" y1="1" x2="12" y2="3"></line>
+              <line x1="12" y1="21" x2="12" y2="23"></line>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+              <line x1="1" y1="12" x2="3" y2="12"></line>
+              <line x1="21" y1="12" x2="23" y2="12"></line>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+            <svg id="dark-mode-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+          </button>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,22 @@
 <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Sports Pals</a>
-    <button id="dark-mode-toggle" class="btn btn-sm dark-mode-toggle ms-2" aria-label="Toggle dark mode">🌙</button>
+    <button id="dark-mode-toggle" class="btn btn-sm btn-outline-secondary border-0 ms-2" aria-label="Toggle dark mode">
+      <svg id="dark-mode-sun" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+        <line x1="1" y1="12" x2="3" y2="12"></line>
+        <line x1="21" y1="12" x2="23" y2="12"></line>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+      </svg>
+      <svg id="dark-mode-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+      </svg>
+    </button>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,7 @@
 <nav class="navbar navbar-expand-md navbar-light bg-light mb-4">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Sports Pals</a>
+    <button id="dark-mode-toggle" class="btn btn-sm dark-mode-toggle ms-2" aria-label="Toggle dark mode">🌙</button>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script>if (localStorage.getItem('darkMode') === 'true') { document.documentElement.classList.add('dark-mode'); }</script>
 
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <script>if (localStorage.getItem('darkMode') === 'true') { document.documentElement.classList.add('dark-mode'); }</script>
+    <script>const t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);</script>
 
   </head>
 

--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -1,7 +1,7 @@
-<th scope="col" colspan="2" class="text-center text-nowrap sortable-header" data-column-index="<%= matchup_counter %>">
+<th scope="col" colspan="2" class="text-center sortable-header" data-column-index="<%= matchup_counter %>" style="width: 10rem; min-width: 10rem; max-width: 10rem;">
   <span class="sortable-header-content">
     <% if !matchup.finished? || matchup.simulated_outcome %>
-      <select class="form-select form-select-sm mb-1 simulation-select" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>" style="font-size: 0.75rem;">
+      <select class="form-select form-select-sm mb-1 simulation-select" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
         <option value=""><%= matchup.simulated_outcome ? 'Clear simulation' : 'Simulate...' %></option>
         <% matchup.possible_remaining_results.each do |name, code| %>
           <option value="<%= code %>" <%= 'selected' if matchup.simulated_outcome == code %>>
@@ -10,8 +10,10 @@
         <% end %>
       </select>
     <% end %>
-    <%= matchup.favorite_name_and_wins %>
+    <% fav_colors = Team.nba_colors(matchup.favorite.tricode) %>
+    <% und_colors = Team.nba_colors(matchup.underdog.tricode) %>
+    <span style="color: <%= fav_colors&.dig(:primary) %>"><%= matchup.favorite_name_and_wins %></span>
     <br>
-    <%= matchup.underdog_name_and_wins %>
+    <span style="color: <%= und_colors&.dig(:primary) %>"><%= matchup.underdog_name_and_wins %></span>
   </span>
 </th>

--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -1,7 +1,7 @@
 <th scope="col" colspan="2" class="text-center text-nowrap sortable-header" data-column-index="<%= matchup_counter %>">
   <span class="sortable-header-content">
     <% if !matchup.finished? || matchup.simulated_outcome %>
-      <select class="form-select form-select-sm mb-1 simulation-select rounded-pill" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
+      <select class="form-select form-select-sm mb-3 simulation-select rounded-pill" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
         <option value=""><%= matchup.simulated_outcome ? 'Clear simulation' : 'Simulate...' %></option>
         <% matchup.possible_remaining_results.each do |name, code| %>
           <option value="<%= code %>" <%= 'selected' if matchup.simulated_outcome == code %>>

--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -10,10 +10,8 @@
         <% end %>
       </select>
     <% end %>
-    <% fav_colors = Team.nba_colors(matchup.favorite.tricode) %>
-    <% und_colors = Team.nba_colors(matchup.underdog.tricode) %>
-    <span data-tricode="<%= matchup.favorite.tricode %>" style="color: <%= fav_colors&.dig(:primary) %>"><%= matchup.favorite_name_and_wins %></span>
+    <%= matchup.favorite_name_and_wins %>
     <br>
-    <span data-tricode="<%= matchup.underdog.tricode %>" style="color: <%= und_colors&.dig(:primary) %>"><%= matchup.underdog_name_and_wins %></span>
+    <%= matchup.underdog_name_and_wins %>
   </span>
 </th>

--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -12,8 +12,8 @@
     <% end %>
     <% fav_colors = Team.nba_colors(matchup.favorite.tricode) %>
     <% und_colors = Team.nba_colors(matchup.underdog.tricode) %>
-    <span style="color: <%= fav_colors&.dig(:primary) %>"><%= matchup.favorite_name_and_wins %></span>
+    <span data-tricode="<%= matchup.favorite.tricode %>" style="color: <%= fav_colors&.dig(:primary) %>"><%= matchup.favorite_name_and_wins %></span>
     <br>
-    <span style="color: <%= und_colors&.dig(:primary) %>"><%= matchup.underdog_name_and_wins %></span>
+    <span data-tricode="<%= matchup.underdog.tricode %>" style="color: <%= und_colors&.dig(:primary) %>"><%= matchup.underdog_name_and_wins %></span>
   </span>
 </th>

--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -1,7 +1,7 @@
-<th scope="col" colspan="2" class="text-center sortable-header" data-column-index="<%= matchup_counter %>" style="width: 10rem; min-width: 10rem; max-width: 10rem;">
+<th scope="col" colspan="2" class="text-center text-nowrap sortable-header" data-column-index="<%= matchup_counter %>">
   <span class="sortable-header-content">
     <% if !matchup.finished? || matchup.simulated_outcome %>
-      <select class="form-select form-select-sm mb-1 simulation-select" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
+      <select class="form-select form-select-sm mb-1 simulation-select rounded-pill" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
         <option value=""><%= matchup.simulated_outcome ? 'Clear simulation' : 'Simulate...' %></option>
         <% matchup.possible_remaining_results.each do |name, code| %>
           <option value="<%= code %>" <%= 'selected' if matchup.simulated_outcome == code %>>

--- a/app/views/round/_overall_total_cell.html.erb
+++ b/app/views/round/_overall_total_cell.html.erb
@@ -1,17 +1,20 @@
 <% overall_user = @data.find { |d| d.user == user_round.user } %>
 <% if overall_user %>
+  <% total_users = @data.length %>
+  <% hue = total_users == 1 ? 120 : (120.0 * (1.0 - (overall_user.rank - 1.0) / (total_users - 1))).round %>
+  <% rank_color = "hsl(#{hue}, 70%, 42%)" %>
   <td class="align-middle overall-total-cell" style="min-width: 90px;" data-max-total="<%= overall_user.max_total %>" data-min-total="<%= overall_user.min_total %>">
     <div class="progress bg-secondary" style="--bs-bg-opacity: .15;">
       <% if overall_user.min_total.positive? %>
         <% pct = (overall_user.min_total.to_f / @biggest_max_total * 100).round(4) %>
-        <div class="progress-bar <%= round_data[:bg_color] %>" role="progressbar" style="width: <%= pct %>%">
+        <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>;">
           <%= overall_user.min_total %>
         </div>
       <% end %>
       <% potential = overall_user.max_total - overall_user.min_total %>
       <% if potential.positive? %>
         <% pct = (potential.to_f / @biggest_max_total * 100).round(4) %>
-        <div class="progress-bar progress-bar-striped <%= round_data[:bg_color] %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
+        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; --bs-bg-opacity: .5;">
           <%= potential %>
         </div>
       <% end %>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -7,16 +7,16 @@
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">
     <% width = (matchup.max_possible_points * 100.0 / user_round.biggest_matchup_max_possible).round(4) %>
-    <div class="progress bg-secondary" data-tricode="<%= pick.winner.tricode %>" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
+    <div class="progress bg-secondary" data-tricode="<%= pick.winner.tricode %>" data-primary-color="<%= colors&.dig(:primary) %>" data-secondary-color="<%= colors&.dig(:secondary) %>" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
       <% if pick.min_points.positive? %>
         <% pct = (pick.min_points_percentage * 100).round(4) %>
-        <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:secondary) %>;">
+        <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:primary) %>;">
           <%= pick.min_points %>
         </div>
       <% end %>
       <% if pick.potential_points.positive? %>
         <% pct = (pick.potential_points_percentage * 100).round(4) %>
-        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:primary) %>; --bs-bg-opacity: .5;">
+        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:primary) %>; opacity: 0.4;">
           <%= pick.potential_points %>
         </div>
       <% end %>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -1,7 +1,8 @@
 <% pick = user_round.picks_by_matchup_id[matchup.id] %>
 <% matchup_index = round_data[:matchups].index(matchup) %>
 <% if pick %>
-  <td class="text-end text-nowrap <%= class_names('table-secondary': !pick.winner_is_favorite) %>" style="width: 1%; padding-inline: 8px;">
+  <% colors = Team.nba_colors(pick.winner.tricode) %>
+  <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px; color: <%= colors&.dig(:primary) %>;">
     <%= pick.winner.short_name %> in <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">
@@ -9,13 +10,13 @@
     <div class="progress bg-secondary" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
       <% if pick.min_points.positive? %>
         <% pct = (pick.min_points_percentage * 100).round(4) %>
-        <div class="progress-bar <%= round_data[:bg_color] %>" role="progressbar" style="width: <%= pct %>%">
+        <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:secondary) %>;">
           <%= pick.min_points %>
         </div>
       <% end %>
       <% if pick.potential_points.positive? %>
         <% pct = (pick.potential_points_percentage * 100).round(4) %>
-        <div class="progress-bar progress-bar-striped <%= round_data[:bg_color] %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
+        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:primary) %>; --bs-bg-opacity: .5;">
           <%= pick.potential_points %>
         </div>
       <% end %>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -1,7 +1,7 @@
 <% pick = user_round.picks_by_matchup_id[matchup.id] %>
 <% matchup_index = round_data[:matchups].index(matchup) %>
 <% if pick %>
-  <% colors = Team.nba_colors(pick.winner.tricode) %>
+  <% colors = pick.winner.colors %>
   <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px;">
     <%= pick.winner.short_name %> in <%= pick.num_games %>
   </td>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -2,12 +2,12 @@
 <% matchup_index = round_data[:matchups].index(matchup) %>
 <% if pick %>
   <% colors = Team.nba_colors(pick.winner.tricode) %>
-  <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px; color: <%= colors&.dig(:primary) %>;">
+  <td class="text-end text-nowrap" data-tricode="<%= pick.winner.tricode %>" style="width: 1%; padding-inline: 8px; color: <%= colors&.dig(:primary) %>;">
     <%= pick.winner.short_name %> in <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">
     <% width = (matchup.max_possible_points * 100.0 / user_round.biggest_matchup_max_possible).round(4) %>
-    <div class="progress bg-secondary" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
+    <div class="progress bg-secondary" data-tricode="<%= pick.winner.tricode %>" style="--bs-bg-opacity: .15; width: <%= width %>%" data-bs-toggle="tooltip" data-bs-html="true" title="<%= pick.points_tooltip %>">
       <% if pick.min_points.positive? %>
         <% pct = (pick.min_points_percentage * 100).round(4) %>
         <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= colors&.dig(:secondary) %>;">

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -2,7 +2,7 @@
 <% matchup_index = round_data[:matchups].index(matchup) %>
 <% if pick %>
   <% colors = Team.nba_colors(pick.winner.tricode) %>
-  <td class="text-end text-nowrap" data-tricode="<%= pick.winner.tricode %>" style="width: 1%; padding-inline: 8px; color: <%= colors&.dig(:primary) %>;">
+  <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px;">
     <%= pick.winner.short_name %> in <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">

--- a/app/views/round/_total_cell.html.erb
+++ b/app/views/round/_total_cell.html.erb
@@ -1,14 +1,17 @@
 <td class="align-middle" style="min-width: 90px;">
+  <% total_users = round_data[:user_data].length %>
+  <% hue = total_users == 1 ? 120 : (120.0 * (1.0 - (user_round.rank - 1.0) / (total_users - 1))).round %>
+  <% rank_color = "hsl(#{hue}, 70%, 42%)" %>
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15;" data-bs-toggle="tooltip" data-bs-html="true" title="<%= user_round.points_tooltip %>">
     <% if user_round.min_total.positive? %>
       <% pct = (user_round.min_total_percentage * 100).round(4) %>
-      <div class="progress-bar <%= round_data[:bg_color] %>" role="progressbar" style="width: <%= pct %>%">
+      <div class="progress-bar" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>;">
         <%= user_round.min_total %>
       </div>
     <% end %>
     <% if user_round.potential_total.positive? %>
       <% pct = (user_round.potential_total_percentage * 100).round(4) %>
-      <div class="progress-bar progress-bar-striped <%= round_data[:bg_color] %>" role="progressbar" style="--bs-bg-opacity: .5; width: <%= pct %>%">
+      <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; --bs-bg-opacity: .5;">
         <%= user_round.potential_total %>
       </div>
     <% end %>

--- a/app/views/round/_total_cell.html.erb
+++ b/app/views/round/_total_cell.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     <% if user_round.potential_total.positive? %>
       <% pct = (user_round.potential_total_percentage * 100).round(4) %>
-      <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; --bs-bg-opacity: .5;">
+      <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; opacity: 0.4;">
         <%= user_round.potential_total %>
       </div>
     <% end %>

--- a/app/views/shared/_user_cell.html.erb
+++ b/app/views/shared/_user_cell.html.erb
@@ -1,13 +1,15 @@
-<td class="table-name-col"
-  data-bs-toggle="tooltip"
-  x-ms-format-detection="none"
-  data-detection="false"
-  <% if current_user %>
-    data-bs-html="true"
-    title="<%= user.username %><br><small><%= user.email %></small>"
-  <% else %>
-    title="<%= user.username %>"
-  <% end %>
->
-  <span x-ms-format-detection="none" data-detection="false"><%= user.username %></span>
+<td class="table-name-col">
+  <span
+    data-bs-toggle="tooltip"
+    data-bs-placement="top"
+    x-ms-format-detection="none"
+    data-detection="false"
+    style="cursor: pointer;"
+    <% if current_user %>
+      data-bs-html="true"
+      title="<%= user.username %><br><small><%= user.email %></small>"
+    <% else %>
+      title="<%= user.username %>"
+    <% end %>
+  ><%= user.username %></span>
 </td>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",
-    "bootstrap": "^5.2.2",
+    "bootstrap": "^5.3.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,10 +1629,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@^5.2.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
-  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
+bootstrap@^5.3.0:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
+  integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
  **Dark Mode**                                                 
                                                                                                                                                                                           
  - Added a light/dark mode toggle button to the navbar, between the Sports Pals brand and Standings link                                                                                  
  - Uses SVG sun/moon icons styled to match the toggle in the fantasy-golf-site                                                                                                            
  - Preference is saved to localStorage and applied immediately on page load (no flash of light mode)                                                                                      
  - Dark mode styles cover the navbar, tables, dropdowns, and alerts                                                                                                                       
                                                                                                                                                                                           
  **Round Table — Team Colors**                                                                                                                                                                
                                                                                                                                                                                           
  - Pick names (e.g. "Hawks in 6") are now colored in each team's primary color                                                                                                            
  - Progress bar fill uses the team's secondary color for confirmed points and primary color for potential points
  - Matchup header team names are color-coded to match                                                                                                                                     
                                                            
  **Round Table — Rank Colors**                                                                                                                                                                
                                                            
  - Round Total progress bars are color-coded green (1st place) through red (last place)                                                                                                   
                                                            
  **Simulate Dropdown**                                                                                                                                                                        
                                                            
  - Restyled as a pill-shaped dropdown with rounded borders, subtle background, and smooth hover/focus transitions                                                                         
  - All simulate dropdowns are a consistent width
  - Dark mode support included                                                                                                                                                             
                                                                                                                                                                                           
  **Name Column Tooltips**
                                                                                                                                                                                           
  - Tooltip now anchors to the username text rather than the full cell, so it appears near the cursor                                                                                      
  - Cursor changes to a pointer on hover
  - Username text stays light in dark mode on hover 