### PR TITLE
Fix sort arrow placement on matchup headers with simulate dropdown

### DIFF
--- a/app/views/round/_matchup_title.html.erb
+++ b/app/views/round/_matchup_title.html.erb
@@ -1,15 +1,15 @@
 <th scope="col" colspan="2" class="text-center text-nowrap sortable-header" data-column-index="<%= matchup_counter %>">
+  <% if !matchup.finished? || matchup.simulated_outcome %>
+    <select class="form-select form-select-sm mb-3 mx-auto simulation-select rounded-pill" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
+      <option value=""><%= matchup.simulated_outcome ? 'Clear simulation' : 'Simulate...' %></option>
+      <% matchup.possible_remaining_results.each do |name, code| %>
+        <option value="<%= code %>" <%= 'selected' if matchup.simulated_outcome == code %>>
+          <%= name %>
+        </option>
+      <% end %>
+    </select>
+  <% end %>
   <span class="sortable-header-content">
-    <% if !matchup.finished? || matchup.simulated_outcome %>
-      <select class="form-select form-select-sm mb-3 simulation-select rounded-pill" data-matchup-id="<%= matchup.id %>" data-round="<%= matchup.round %>">
-        <option value=""><%= matchup.simulated_outcome ? 'Clear simulation' : 'Simulate...' %></option>
-        <% matchup.possible_remaining_results.each do |name, code| %>
-          <option value="<%= code %>" <%= 'selected' if matchup.simulated_outcome == code %>>
-            <%= name %>
-          </option>
-        <% end %>
-      </select>
-    <% end %>
     <%= matchup.favorite_name_and_wins %>
     <br>
     <%= matchup.underdog_name_and_wins %>


### PR DESCRIPTION
Screenshots below.

## Summary

Fixes sort-arrow placement on matchup column headers that contain the "Simulate..." dropdown. Arrows now sit next to the team names instead of floating off to the upper-right.

## How it was introduced

#158 (Design refresh) pinned the simulate dropdown to a fixed `width: 10rem` and switched it to a pill shape. The dropdown lived inside the same `.sortable-header-content` span that the sort-arrow `::after` pseudo-elements position against (`left: calc(100% + 0.5em); top: 50%`). Because `.sortable-header-content` is `display: inline-block`, its bounding box grew to fit the now-wider dropdown — so the arrows ended up to the right of the dropdown's edge (not the team names') and vertically centered over the whole stack. Headers without a dropdown were unaffected, which is why this slipped through review.

## Fix

- Move the `<select>` out of `.sortable-header-content`, so the span wraps only the two team-name lines. Arrows now position relative to the names in both the with-simulate and no-simulate cases, matching the pre-#158 behavior.
- Add `mx-auto` to the `<select>` to keep it centered under the names. Bootstrap's `.form-select` is `display: block`, and the `<th>`'s `text-center` only centers inline content — without the auto-margin, the dropdown would sit flush left.

## Before / after

<!-- screenshots -->

## Test plan

- [x] Round page with unfinished matchups: dropdown is centered, arrows sit next to the team names.
- [x] Round page with finished matchups (no dropdown): arrows still render in the same spot as before.
- [x] Clicking the dropdown opens it without triggering a column sort.
- [x] Clicking the team-names area still sorts the column.
- [ ] Light and dark mode both render correctly.

<img width="393" height="463" alt="Screenshot 2026-04-22 at 12 23 47 AM" src="https://github.com/user-attachments/assets/9c3c3a7e-803b-4e5f-bb0a-1cf1da9f57d0" />

<img width="371" height="446" alt="Screenshot 2026-04-22 at 12 30 31 AM" src="https://github.com/user-attachments/assets/5eea20c3-5f58-44cc-b171-24220c06faed" />
