### PR TITLE
Design refresh follow-ups: navbar, table headers, status colors, cursor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-debug.log*
 
 .env
 coverage
+.claude/settings.local.json

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -39,12 +39,7 @@ th:nth-child(2), td:nth-child(2) {
   min-width: 50vw;
 }
 
-.table.table-white {
-  --bs-table-bg: #fff;
-  background-color: #fff !important;
-}
-
-.table.table-white tbody td,
-.table.table-white tbody th {
+.table tbody td,
+.table tbody th {
   border-bottom-width: 0;
 }

--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -2,23 +2,10 @@
 // This file contains only app-specific overrides.
 
 [data-bs-theme="dark"] {
-  // Match body bg to table bg so tables don't look like floating boxes
-  body {
-    background-color: #2b3035;
-    color: #dee2e6;
-  }
-
-  .table.table-white {
-    --bs-table-bg: #2b3035 !important;
-    --bs-table-color: #dee2e6 !important;
-    --bs-table-hover-color: #dee2e6 !important;
-    background-color: #2b3035 !important;
-    color: #dee2e6 !important;
-  }
-
-  // Sticky column needs explicit bg to avoid bleed-through
+  // Sticky column needs an explicit bg (matching body) to avoid
+  // bleed-through when the table scrolls horizontally.
   .table-name-col {
-    background-color: #2b3035;
+    background-color: var(--bs-body-bg);
   }
 
   // Keep name text visible on row hover
@@ -29,5 +16,4 @@
       color: #fff;
     }
   }
-
 }

--- a/app/assets/stylesheets/round.scss
+++ b/app/assets/stylesheets/round.scss
@@ -39,3 +39,15 @@
     }
   }
 }
+
+// Indicator placed before the current user's pick in matchup summary
+// cells, replacing the previous bold-text treatment.
+.user-pick-dot {
+  display: inline-block;
+  width: 0.45em;
+  height: 0.45em;
+  border-radius: 50%;
+  background-color: var(--bs-primary);
+  margin-right: 0.4em;
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -83,6 +83,14 @@
   border-bottom-width: 0;
 }
 
+// The table is read, not edited or quoted — drop the text I-beam in
+// favor of a default arrow. Cells with their own cursor (sortable
+// headers, simulate dropdown) keep their pointer via more specific
+// rules.
+.table {
+  cursor: default;
+}
+
 // Modern data-table header treatment: small uppercase muted-gray labels
 // instead of bold black headings.
 .table > thead > tr > th {

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -73,19 +73,19 @@
   z-index: 1;
 }
 
-.table.table-white th,
-.table.table-white td {
+.table th,
+.table td {
   padding-inline: 0.5rem;
 }
 
-.table.table-white tfoot td,
-.table.table-white tfoot th {
+.table tfoot td,
+.table tfoot th {
   border-bottom-width: 0;
 }
 
 // Modern data-table header treatment: small uppercase muted-gray labels
 // instead of bold black headings.
-.table.table-white > thead > tr > th {
+.table > thead > tr > th {
   font-weight: 500;
   font-size: 0.75rem;
   letter-spacing: 0.06em;

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -82,3 +82,13 @@
 .table.table-white tfoot th {
   border-bottom-width: 0;
 }
+
+// Modern data-table header treatment: small uppercase muted-gray labels
+// instead of bold black headings.
+.table.table-white > thead > tr > th {
+  font-weight: 500;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md mb-4">
+<nav class="navbar navbar-expand-md mb-4 bg-body-tertiary">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Sports Pals</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>Sports Pals</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="format-detection" content="email=no, telephone=no, date=no, address=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/round/_matchup_summary_entry.html.erb
+++ b/app/views/round/_matchup_summary_entry.html.erb
@@ -1,12 +1,12 @@
 <% count = @matchup_data[matchup.id][outcome] || 0 %>
 <% total = @matchup_data[matchup.id][:total] %>
 <% winner, num_games, possible = matchup.outcome_by_index(outcome) %>
-<% bg = "bg-danger bg-gradient text-white text-decoration-line-through" unless possible %>
-<% bg = "bg-success bg-gradient text-white" if possible && matchup.finished? %>
+<% bg = "text-body-tertiary" unless possible %>
+<% bg = "fw-bold" if possible && matchup.finished? %>
 <% current_user_pick = current_user_round&.picks_by_matchup_id&.[](matchup.id) %>
 <% is_user_pick = current_user_pick&.winner == winner && current_user_pick&.num_games == num_games %>
-<td class="text-end text-nowrap <%= bg %> <%= 'fw-bold' if is_user_pick %>"><%= winner.short_name %> in <%= num_games %></td>
-<td class="align-middle" style="min-width: 75px;">
+<td class="text-end text-nowrap <%= bg %>"><% if is_user_pick %><span class="user-pick-dot" title="Your pick"></span><% end %><%= winner.short_name %> in <%= num_games %></td>
+<td class="align-middle <%= 'opacity-25' unless possible %>" style="min-width: 75px;">
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15" data-bs-toggle="tooltip" data-bs-html="true" title="<%= "#{count} #{"person".pluralize(count)} picked #{winner.name} in #{num_games}." %>">
     <% pct = (count.to_f * 100 / total).round(4) %>
     <div class="progress-bar bg-secondary" role="progressbar" style="width: <%= pct %>%">

--- a/app/views/round/_round_table.html.erb
+++ b/app/views/round/_round_table.html.erb
@@ -1,5 +1,5 @@
 <div class="table-responsive">
-  <table class="table table-hover table-sm table-white">
+  <table class="table table-hover table-sm">
     <thead>
       <tr>
         <th scope="col" class="table-rank-col">#</th>

--- a/app/views/shared/_user_cell.html.erb
+++ b/app/views/shared/_user_cell.html.erb
@@ -4,7 +4,6 @@
     data-bs-placement="top"
     x-ms-format-detection="none"
     data-detection="false"
-    style="cursor: pointer;"
     <% if current_user %>
       data-bs-html="true"
       title="<%= user.username %><br><small><%= user.email %></small>"

--- a/app/views/shared/_user_cell.html.erb
+++ b/app/views/shared/_user_cell.html.erb
@@ -2,8 +2,6 @@
   <span
     data-bs-toggle="tooltip"
     data-bs-placement="top"
-    x-ms-format-detection="none"
-    data-detection="false"
     <% if current_user %>
       data-bs-html="true"
       title="<%= user.username %><br><small><%= user.email %></small>"

--- a/app/views/standings/_progress_table.html.erb
+++ b/app/views/standings/_progress_table.html.erb
@@ -1,5 +1,5 @@
 <div class= "table-responsive">
-  <table class="table table-hover table-sm table-white">
+  <table class="table table-hover table-sm">
     <thead>
       <tr>
         <th scope="col" class="table-rank-col">#</th>


### PR DESCRIPTION
Here are the new navbar and table headings.

<img width="1953" height="468" alt="Screenshot 2026-05-01 at 12 43 48 PM" src="https://github.com/user-attachments/assets/5d5ef045-ba1e-45f8-9332-1a715a923d2b" />
<img width="1953" height="468" alt="Screenshot 2026-05-01 at 12 43 44 PM" src="https://github.com/user-attachments/assets/393a7057-aad0-4801-b211-da938f944bb1" />

## Summary

A small follow-up pass on the design refresh from #158, focused on visual coherence rather than structural change. Each commit is self-contained.

- **Tint navbar with `bg-body-tertiary`** — closes #163. The navbar lost its background tint in the 5.3 dark-mode migration; this puts back a theme-aware faint band so it reads as distinct from the body in both modes.
- **Restyle table headers** as small uppercase muted-gray labels (12px, letter-spaced, secondary text color) instead of bold black — a more "data-table" treatment.
- **Drop the `.table-white` forced-bg system.** The class hard-coded white on tables with `!important`, which broke Bootstrap's theming and required a chain of dark-mode overrides (body bg, table bg, color, sticky-col bg) all pinned to `#2b3035` just to undo the forced white. With it gone, Bootstrap's default theming does the right thing, and the navbar's tertiary tint becomes visibly distinct from the body in dark mode for the first time. Sticky `.table-name-col` now uses `var(--bs-body-bg)` instead of a hardcoded hex.
- **Soften matchup summary status colors** — replace saturated `bg-danger` / `bg-success` with `text-body-tertiary` (eliminated, also drops the adjacent progress bar to `opacity-25`) and `fw-bold` (determined). The current user's pick was previously bolded too; switch to a small primary-colored dot before the cell text so bold can signal "this outcome happened" without colliding. Fixes #161 
- **Drop misleading cursors** — the user-cell span had `cursor: pointer` advertising a tooltip but clicking did nothing. Remove it; also set `.table { cursor: default; }` since a leaderboard isn't something you select or quote. Sortable headers and the simulate dropdown keep their pointer via more-specific rules.
- **Disable iOS Safari format-detection** so usernames that look like emails stop being turned into mailto links on iOS. The standard fix is a page-level `<meta name=\"format-detection\">` tag; the previously-attempted `x-ms-format-detection` / `data-detection` attributes don't actually do anything for iOS Safari and are removed.

## Test plan

- [x] Standings (overall + each round) in light mode — navbar is distinct, table headers are small/uppercase/gray, no visible regressions in the rest of the table.
- [x] Same in dark mode — body and table take Bootstrap's `#212529`, navbar tertiary is visibly lighter.
- [x] A round with finished, partially-finished, and unfinished matchups — eliminated entries are muted with faded progress bars, determined entries are bold, current user's pick has a small dot indicator.
- [x] Hover a user name — tooltip still works; cursor is the default arrow throughout the table; sortable headers and simulate dropdown still show the pointer cursor.
- [ ] Open on iOS Safari with a user whose username contains an email — text is no longer auto-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)