### PR TITLE
Add "follow system" as a third theme option

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -51,23 +51,50 @@ function applyTeamColors() {
     });
 }
 
+function getStoredTheme() {
+    const v = localStorage.getItem('theme');
+    return (v === 'light' || v === 'dark') ? v : 'auto';
+}
+
+function systemTheme() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolvedTheme() {
+    const s = getStoredTheme();
+    return s === 'auto' ? systemTheme() : s;
+}
+
+function updateThemeIcons() {
+    const stored = getStoredTheme();
+    const sun = document.getElementById('dark-mode-sun');
+    const moon = document.getElementById('dark-mode-moon');
+    const monitor = document.getElementById('dark-mode-monitor');
+    if (!sun || !moon || !monitor) return;
+    sun.style.display = stored === 'light' ? 'block' : 'none';
+    moon.style.display = stored === 'dark' ? 'block' : 'none';
+    monitor.style.display = stored === 'auto' ? 'block' : 'none';
+}
+
+function applyTheme() {
+    document.documentElement.setAttribute('data-bs-theme', resolvedTheme());
+    updateThemeIcons();
+    applyTeamColors();
+}
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (getStoredTheme() === 'auto') applyTheme();
+});
+
 document.addEventListener("turbolinks:load", () => {
     const toggle = document.getElementById('dark-mode-toggle');
     if (toggle) {
-        const sun = document.getElementById('dark-mode-sun');
-        const moon = document.getElementById('dark-mode-moon');
-        const isDark = () => document.documentElement.getAttribute('data-bs-theme') === 'dark';
-        const updateIcons = () => {
-            sun.style.display = isDark() ? 'block' : 'none';
-            moon.style.display = isDark() ? 'none' : 'block';
-        };
-        updateIcons();
+        updateThemeIcons();
         toggle.addEventListener('click', () => {
-            const theme = isDark() ? 'light' : 'dark';
-            document.documentElement.setAttribute('data-bs-theme', theme);
-            localStorage.setItem('theme', theme);
-            updateIcons();
-            applyTeamColors();
+            const next = { auto: 'light', light: 'dark', dark: 'auto' }[getStoredTheme()];
+            if (next === 'auto') localStorage.removeItem('theme');
+            else localStorage.setItem('theme', next);
+            applyTheme();
         });
     }
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -37,7 +37,7 @@
         <%= render 'devise/menu/registration_items' %>
         <%= render 'devise/menu/login_items' %>
         <li class="nav-item">
-          <button id="dark-mode-toggle" class="btn btn-sm btn-outline-secondary border-0 nav-link" aria-label="Toggle dark mode">
+          <button id="dark-mode-toggle" class="btn btn-sm btn-outline-secondary border-0 nav-link" aria-label="Toggle theme">
             <svg id="dark-mode-sun" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="5"></circle>
               <line x1="12" y1="1" x2="12" y2="3"></line>
@@ -49,8 +49,13 @@
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
             </svg>
-            <svg id="dark-mode-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg id="dark-mode-moon" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+            <svg id="dark-mode-monitor" style="display:none" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="4" width="20" height="13" rx="2"></rect>
+              <line x1="8" y1="21" x2="16" y2="21"></line>
+              <line x1="12" y1="17" x2="12" y2="21"></line>
             </svg>
           </button>
         </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <script>const t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);</script>
+    <script>(function(){var s=localStorage.getItem('theme');var t=(s==='light'||s==='dark')?s:(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);})();</script>
 
   </head>
 


### PR DESCRIPTION
## Summary

Closes #162.

- Theme now cycles **auto → light → dark → auto**. `auto` = no `theme` key in localStorage.
- In `auto`, the page follows the OS preference live via a `matchMedia('(prefers-color-scheme: dark)')` `change` listener — no more "site stuck on light when macOS sunsets to dark."
- Navbar icon reflects the stored preference (sun / moon / monitor), not the resolved theme — so it shows what clicking will do next.

## Implementation notes

- Preload script in `application.html.erb` only honors `'light'`/`'dark'` from localStorage; anything else (including the new `auto` = absent) resolves through `matchMedia`. Preserved as one inline line to avoid FOUC.
- The `matchMedia` `change` listener is attached at module top-level in `application.js`, not inside `turbolinks:load`, so Turbolinks navigations don't stack listeners.
- `applyTeamColors()` is reused unchanged — it already reads the resolved `data-bs-theme` from the DOM, so progress-bar team colors re-pick correctly on live OS changes.

## Test plan

- [x] Fresh session (no `theme` in localStorage): page renders in OS theme; monitor icon shown.
- [x] Click cycles light → dark → auto, with localStorage and icon staying in sync; `auto` removes the key.
- [x] In `auto`, flipping macOS appearance updates the page live with no reload.
- [x] When pinned to light or dark, OS changes do not affect the page.
- [x] Turbolinks navigation preserves theme + icon; only one matchMedia handler fires per OS change.