### PR TITLE
Flip tooltips to match active theme

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,16 @@
 @import "~bootstrap/scss/bootstrap";
+
+// Flip Bootstrap's default inverted tooltips so they match the active theme:
+// light tooltip in light mode, dark tooltip in dark mode (matches GitHub,
+// Linear, Radix, shadcn, etc). Lives here (not in Sprockets) so it loads
+// after Bootstrap.
+.tooltip {
+  --bs-tooltip-bg: var(--bs-body-bg);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-opacity: 1;
+}
+
+.tooltip .tooltip-inner {
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
## Summary
- Override Bootstrap 5.3's tooltip CSS variables so tooltips match the active theme (light tooltip in light mode, dark tooltip in dark mode) instead of inverting it.
- Add a subtle border and shadow on `.tooltip-inner` so the tooltip still reads as an elevated surface, and set `--bs-tooltip-opacity: 1` since the matched-theme style looks smudged at the default 0.9.
- Lives in the webpack stylesheet (not Sprockets) so it loads after Bootstrap and wins the cascade.

## Why
Bootstrap's default inverted tooltips are inconsistent with how popovers/menus/dropdowns render in this app, and modern design systems (GitHub, Linear, Radix, shadcn, Vercel, Stripe, Notion) all use matched-theme tooltips.

## Test plan
- [x] Hover a tooltipped element (e.g. a username in the standings table) in light mode → light tooltip with dark text.
- [x] Toggle to dark mode → dark tooltip with light text.
- [x] Confirm border + shadow are visible in both modes and the tooltip reads as fully opaque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)