### PR TITLE
Use NBA team logos in pick and matchup summary cells

### DIFF
--- a/app/assets/stylesheets/dark_mode.scss
+++ b/app/assets/stylesheets/dark_mode.scss
@@ -17,3 +17,14 @@
     }
   }
 }
+
+// Team logos: render both variants, show the one matching the active theme.
+.team-logo {
+  display: inline-block;
+  vertical-align: middle;
+}
+.team-logo--dark { display: none; }
+[data-bs-theme="dark"] {
+  .team-logo--light { display: none; }
+  .team-logo--dark { display: inline-block; }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  # Renders both light- and dark-mode variants of a team's logo; CSS shows
+  # the one matching the active `data-bs-theme` on <html>.
+  # Returns nil if the team has no external_id (no logo available).
+  def team_logo_tag(team, size: 24, **options)
+    return nil unless team&.external_id
+
+    classes = ["team-logo", options.delete(:class)].compact.join(" ")
+    alt = options.delete(:alt) || "#{team.full_name} logo"
+
+    safe_join([
+      image_tag(team.logo_url(theme: :light),
+        class: "#{classes} team-logo--light",
+        alt: alt, width: size, height: size, loading: "lazy", **options),
+      image_tag(team.logo_url(theme: :dark),
+        class: "#{classes} team-logo--dark",
+        alt: alt, width: size, height: size, loading: "lazy", **options)
+    ])
+  end
 end

--- a/app/lib/team.rb
+++ b/app/lib/team.rb
@@ -1,13 +1,21 @@
 class Team
-  attr_reader :tricode, :city, :name, :nickname, :primary_color, :secondary_color
+  attr_reader :tricode, :city, :name, :nickname, :primary_color, :secondary_color, :external_id
 
-  def initialize(tricode, city, name, nickname = nil, primary_color: nil, secondary_color: nil)
+  def initialize(tricode, city, name, nickname = nil, primary_color: nil, secondary_color: nil, external_id: nil)
     @tricode = tricode
     @city = city
     @name = name
     @nickname = nickname
     @primary_color = primary_color
     @secondary_color = secondary_color
+    @external_id = external_id
+  end
+
+  def logo_url(theme: :light)
+    return nil unless external_id
+
+    variant = (theme.to_sym == :dark) ? "D" : "L"
+    "https://cdn.nba.com/logos/nba/#{external_id}/primary/#{variant}/logo.svg"
   end
 
   def full_name
@@ -55,6 +63,39 @@ class Team
     was: {primary: "#002B5C", secondary: "#E31837"}
   }.freeze
 
+  NBA_EXTERNAL_IDS = {
+    atl: 1610612737,
+    bkn: 1610612751,
+    bos: 1610612738,
+    cha: 1610612766,
+    chi: 1610612741,
+    cle: 1610612739,
+    dal: 1610612742,
+    den: 1610612743,
+    det: 1610612765,
+    gsw: 1610612744,
+    hou: 1610612745,
+    ind: 1610612754,
+    lac: 1610612746,
+    lal: 1610612747,
+    mem: 1610612763,
+    mia: 1610612748,
+    mil: 1610612749,
+    min: 1610612750,
+    nop: 1610612740,
+    nyk: 1610612752,
+    okc: 1610612760,
+    orl: 1610612753,
+    phi: 1610612755,
+    phx: 1610612756,
+    por: 1610612757,
+    sac: 1610612758,
+    sas: 1610612759,
+    tor: 1610612761,
+    uta: 1610612762,
+    was: 1610612764
+  }.freeze
+
   NBA_TEAMS = [
     [:atl, "Atlanta", "Hawks"],
     [:bkn, "Brooklyn", "Nets"],
@@ -88,7 +129,7 @@ class Team
     [:was, "Washington", "Wizards"]
   ].to_h do |tc, c, n, nn|
     colors = NBA_COLORS[tc] || {}
-    [tc, Team.new(tc, c, n, nn, primary_color: colors[:primary], secondary_color: colors[:secondary])]
+    [tc, Team.new(tc, c, n, nn, primary_color: colors[:primary], secondary_color: colors[:secondary], external_id: NBA_EXTERNAL_IDS[tc])]
   end.with_indifferent_access
 
   MLB_TEAMS = [

--- a/app/lib/team.rb
+++ b/app/lib/team.rb
@@ -1,13 +1,12 @@
 class Team
-  attr_reader :tricode, :city, :name, :nickname, :primary_color, :secondary_color, :external_id
+  attr_reader :tricode, :city, :name, :nickname, :colors, :external_id
 
-  def initialize(tricode, city, name, nickname = nil, primary_color: nil, secondary_color: nil, external_id: nil)
+  def initialize(tricode, city:, name:, nickname: nil, colors: {}, external_id: nil)
     @tricode = tricode
     @city = city
     @name = name
     @nickname = nickname
-    @primary_color = primary_color
-    @secondary_color = secondary_color
+    @colors = colors
     @external_id = external_id
   end
 
@@ -26,144 +25,78 @@ class Team
     nickname || name
   end
 
-  def colors
-    {primary: primary_color, secondary: secondary_color}
-  end
-
-  NBA_COLORS = {
-    atl: {primary: "#E03A3E", secondary: "#C1D32F"},
-    bkn: {primary: "#000000", secondary: "#AAAAAA"},
-    bos: {primary: "#007A33", secondary: "#BA9653"},
-    cha: {primary: "#1D1160", secondary: "#00788C"},
-    chi: {primary: "#CE1141", secondary: "#000000"},
-    cle: {primary: "#FDBB30", secondary: "#C8004A"},
-    dal: {primary: "#00538C", secondary: "#002B5E"},
-    den: {primary: "#FEC524", secondary: "#2E86C1"},
-    det: {primary: "#C8102E", secondary: "#006BB6"},
-    gsw: {primary: "#1D428A", secondary: "#FFC72C"},
-    hou: {primary: "#CE1141", secondary: "#000000"},
-    ind: {primary: "#002D62", secondary: "#FDBB30"},
-    lac: {primary: "#C8102E", secondary: "#1D428A"},
-    lal: {primary: "#552583", secondary: "#FDB927"},
-    mem: {primary: "#5D76A9", secondary: "#12173F"},
-    mia: {primary: "#98002E", secondary: "#F9A01B"},
-    mil: {primary: "#00471B", secondary: "#EEE1C6"},
-    min: {primary: "#2E9FD8", secondary: "#236192"},
-    nop: {primary: "#0C2340", secondary: "#C8102E"},
-    nyk: {primary: "#006BB6", secondary: "#F58426"},
-    okc: {primary: "#007AC1", secondary: "#EF3B24"},
-    orl: {primary: "#0077C0", secondary: "#C4CED4"},
-    phi: {primary: "#006BB6", secondary: "#ED174C"},
-    phx: {primary: "#1D1160", secondary: "#E56020"},
-    por: {primary: "#E03A3E", secondary: "#000000"},
-    sac: {primary: "#5A2D81", secondary: "#63727A"},
-    sas: {primary: "#000000", secondary: "#C4CED4"},
-    tor: {primary: "#CE1141", secondary: "#000000"},
-    uta: {primary: "#002B5C", secondary: "#00471B"},
-    was: {primary: "#002B5C", secondary: "#E31837"}
+  NBA_TEAM_DATA = {
+    atl: {city: "Atlanta", name: "Hawks", colors: {primary: "#E03A3E", secondary: "#C1D32F"}, external_id: 1610612737},
+    bkn: {city: "Brooklyn", name: "Nets", colors: {primary: "#000000", secondary: "#AAAAAA"}, external_id: 1610612751},
+    bos: {city: "Boston", name: "Celtics", colors: {primary: "#007A33", secondary: "#BA9653"}, external_id: 1610612738},
+    cha: {city: "Charlotte", name: "Hornets", colors: {primary: "#1D1160", secondary: "#00788C"}, external_id: 1610612766},
+    chi: {city: "Chicago", name: "Bulls", colors: {primary: "#CE1141", secondary: "#000000"}, external_id: 1610612741},
+    cle: {city: "Cleveland", name: "Cavaliers", nickname: "Cavs", colors: {primary: "#FDBB30", secondary: "#C8004A"}, external_id: 1610612739},
+    dal: {city: "Dallas", name: "Mavericks", nickname: "Mavs", colors: {primary: "#00538C", secondary: "#002B5E"}, external_id: 1610612742},
+    den: {city: "Denver", name: "Nuggets", colors: {primary: "#FEC524", secondary: "#2E86C1"}, external_id: 1610612743},
+    det: {city: "Detroit", name: "Pistons", colors: {primary: "#C8102E", secondary: "#006BB6"}, external_id: 1610612765},
+    gsw: {city: "Golden State", name: "Warriors", colors: {primary: "#1D428A", secondary: "#FFC72C"}, external_id: 1610612744},
+    hou: {city: "Houston", name: "Rockets", colors: {primary: "#CE1141", secondary: "#000000"}, external_id: 1610612745},
+    ind: {city: "Indiana", name: "Pacers", colors: {primary: "#002D62", secondary: "#FDBB30"}, external_id: 1610612754},
+    lac: {city: "Los Angeles", name: "Clippers", colors: {primary: "#C8102E", secondary: "#1D428A"}, external_id: 1610612746},
+    lal: {city: "Los Angeles", name: "Lakers", colors: {primary: "#552583", secondary: "#FDB927"}, external_id: 1610612747},
+    mem: {city: "Memphis", name: "Grizzlies", colors: {primary: "#5D76A9", secondary: "#12173F"}, external_id: 1610612763},
+    mia: {city: "Miami", name: "Heat", colors: {primary: "#98002E", secondary: "#F9A01B"}, external_id: 1610612748},
+    mil: {city: "Milwaukee", name: "Bucks", colors: {primary: "#00471B", secondary: "#EEE1C6"}, external_id: 1610612749},
+    min: {city: "Minnesota", name: "Timberwolves", nickname: "T'wolves", colors: {primary: "#2E9FD8", secondary: "#236192"}, external_id: 1610612750},
+    nop: {city: "New Orleans", name: "Pelicans", colors: {primary: "#0C2340", secondary: "#C8102E"}, external_id: 1610612740},
+    nyk: {city: "New York", name: "Knicks", colors: {primary: "#006BB6", secondary: "#F58426"}, external_id: 1610612752},
+    okc: {city: "Oklahoma City", name: "Thunder", colors: {primary: "#007AC1", secondary: "#EF3B24"}, external_id: 1610612760},
+    orl: {city: "Orlando", name: "Magic", colors: {primary: "#0077C0", secondary: "#C4CED4"}, external_id: 1610612753},
+    phi: {city: "Philadelphia", name: "76ers", colors: {primary: "#006BB6", secondary: "#ED174C"}, external_id: 1610612755},
+    phx: {city: "Phoenix", name: "Suns", colors: {primary: "#1D1160", secondary: "#E56020"}, external_id: 1610612756},
+    por: {city: "Portland", name: "Trail Blazers", nickname: "Blazers", colors: {primary: "#E03A3E", secondary: "#000000"}, external_id: 1610612757},
+    sac: {city: "Sacramento", name: "Kings", colors: {primary: "#5A2D81", secondary: "#63727A"}, external_id: 1610612758},
+    sas: {city: "San Antonio", name: "Spurs", colors: {primary: "#000000", secondary: "#C4CED4"}, external_id: 1610612759},
+    tor: {city: "Toronto", name: "Raptors", colors: {primary: "#CE1141", secondary: "#000000"}, external_id: 1610612761},
+    uta: {city: "Utah", name: "Jazz", colors: {primary: "#002B5C", secondary: "#00471B"}, external_id: 1610612762},
+    was: {city: "Washington", name: "Wizards", colors: {primary: "#002B5C", secondary: "#E31837"}, external_id: 1610612764}
   }.freeze
 
-  NBA_EXTERNAL_IDS = {
-    atl: 1610612737,
-    bkn: 1610612751,
-    bos: 1610612738,
-    cha: 1610612766,
-    chi: 1610612741,
-    cle: 1610612739,
-    dal: 1610612742,
-    den: 1610612743,
-    det: 1610612765,
-    gsw: 1610612744,
-    hou: 1610612745,
-    ind: 1610612754,
-    lac: 1610612746,
-    lal: 1610612747,
-    mem: 1610612763,
-    mia: 1610612748,
-    mil: 1610612749,
-    min: 1610612750,
-    nop: 1610612740,
-    nyk: 1610612752,
-    okc: 1610612760,
-    orl: 1610612753,
-    phi: 1610612755,
-    phx: 1610612756,
-    por: 1610612757,
-    sac: 1610612758,
-    sas: 1610612759,
-    tor: 1610612761,
-    uta: 1610612762,
-    was: 1610612764
+  MLB_TEAM_DATA = {
+    ari: {city: "Arizona", name: "Diamondbacks"},
+    atl: {city: "Atlanta", name: "Barves"},
+    bal: {city: "Baltimore", name: "Orioles"},
+    bos: {city: "Boston", name: "Red Sox"},
+    chc: {city: "Chicago", name: "Cubs"},
+    cin: {city: "Cincinnati", name: "Reds"},
+    cle: {city: "Cleveland", name: "Guardians"},
+    col: {city: "Colorado", name: "Rockies"},
+    cws: {city: "Chicago", name: "White Sox"},
+    det: {city: "Detroit", name: "Tigers"},
+    hou: {city: "Houston", name: "Astros"},
+    kc: {city: "Kansas City", name: "Royals"},
+    laa: {city: "Los Angeles", name: "Angels"},
+    lad: {city: "Los Angeles", name: "Dodgers"},
+    mia: {city: "Miami", name: "Marlins"},
+    mil: {city: "Milwaukee", name: "Brewers"},
+    min: {city: "Minnesota", name: "Twins"},
+    nym: {city: "New York", name: "Mets"},
+    nyy: {city: "New York", name: "Yankees"},
+    oak: {city: "Oakland", name: "Athletics"},
+    phi: {city: "Philadelphia", name: "Phillies"},
+    pit: {city: "Pittsburgh", name: "Pirates"},
+    sd: {city: "San Diego", name: "Padres"},
+    sea: {city: "Seattle", name: "Mariners"},
+    sf: {city: "San Francisco", name: "Giants"},
+    stl: {city: "St. Louis", name: "Cardinals"},
+    tb: {city: "Tampa Bay", name: "Rays"},
+    tex: {city: "Texas", name: "Rangers"},
+    tor: {city: "Toronto", name: "Blue Jays"},
+    wsh: {city: "Washington", name: "Nationals"}
   }.freeze
 
-  NBA_TEAMS = [
-    [:atl, "Atlanta", "Hawks"],
-    [:bkn, "Brooklyn", "Nets"],
-    [:bos, "Boston", "Celtics"],
-    [:cha, "Charlotte", "Hornets"],
-    [:chi, "Chicago", "Bulls"],
-    [:cle, "Cleveland", "Cavaliers", "Cavs"],
-    [:dal, "Dallas", "Mavericks", "Mavs"],
-    [:den, "Denver", "Nuggets"],
-    [:det, "Detroit", "Pistons"],
-    [:gsw, "Golden State", "Warriors"],
-    [:hou, "Houston", "Rockets"],
-    [:ind, "Indiana", "Pacers"],
-    [:lac, "Los Angeles", "Clippers"],
-    [:lal, "Los Angeles", "Lakers"],
-    [:mem, "Memphis", "Grizzlies"],
-    [:mia, "Miami", "Heat"],
-    [:mil, "Milwaukee", "Bucks"],
-    [:min, "Minnesota", "Timberwolves", "T'wolves"],
-    [:nop, "New Orleans", "Pelicans"],
-    [:nyk, "New York", "Knicks"],
-    [:okc, "Oklahoma City", "Thunder"],
-    [:orl, "Orlando", "Magic"],
-    [:phi, "Philadelphia", "76ers"],
-    [:phx, "Phoenix", "Suns"],
-    [:por, "Portland", "Trail Blazers", "Blazers"],
-    [:sac, "Sacramento", "Kings"],
-    [:sas, "San Antonio", "Spurs"],
-    [:tor, "Toronto", "Raptors"],
-    [:uta, "Utah", "Jazz"],
-    [:was, "Washington", "Wizards"]
-  ].to_h do |tc, c, n, nn|
-    colors = NBA_COLORS[tc] || {}
-    [tc, Team.new(tc, c, n, nn, primary_color: colors[:primary], secondary_color: colors[:secondary], external_id: NBA_EXTERNAL_IDS[tc])]
-  end.with_indifferent_access
+  NBA_TEAMS = NBA_TEAM_DATA
+    .to_h { |tc, attrs| [tc, Team.new(tc, **attrs)] }
+    .with_indifferent_access
 
-  MLB_TEAMS = [
-    [:ari, "Arizona", "Diamondbacks"],
-    [:atl, "Atlanta", "Barves"],
-    [:bal, "Baltimore", "Orioles"],
-    [:bos, "Boston", "Red Sox"],
-    [:chc, "Chicago", "Cubs"],
-    [:cin, "Cincinnati", "Reds"],
-    [:cle, "Cleveland", "Guardians"],
-    [:col, "Colorado", "Rockies"],
-    [:cws, "Chicago", "White Sox"],
-    [:det, "Detroit", "Tigers"],
-    [:hou, "Houston", "Astros"],
-    [:kc, "Kansas City", "Royals"],
-    [:laa, "Los Angeles", "Angels"],
-    [:lad, "Los Angeles", "Dodgers"],
-    [:mia, "Miami", "Marlins"],
-    [:mil, "Milwaukee", "Brewers"],
-    [:min, "Minnesota", "Twins"],
-    [:nym, "New York", "Mets"],
-    [:nyy, "New York", "Yankees"],
-    [:oak, "Oakland", "Athletics"],
-    [:phi, "Philadelphia", "Phillies"],
-    [:pit, "Pittsburgh", "Pirates"],
-    [:sd, "San Diego", "Padres"],
-    [:sea, "Seattle", "Mariners"],
-    [:sf, "San Francisco", "Giants"],
-    [:stl, "St. Louis", "Cardinals"],
-    [:tb, "Tampa Bay", "Rays"],
-    [:tex, "Texas", "Rangers"],
-    [:tor, "Toronto", "Blue Jays"],
-    [:wsh, "Washington", "Nationals"]
-  ].to_h { |tc, c, n, nn| [tc, Team.new(tc, c, n, nn)] }
+  MLB_TEAMS = MLB_TEAM_DATA
+    .to_h { |tc, attrs| [tc, Team.new(tc, **attrs)] }
     .with_indifferent_access
 
   class << self

--- a/app/views/round/_matchup_summary_entry.html.erb
+++ b/app/views/round/_matchup_summary_entry.html.erb
@@ -5,7 +5,7 @@
 <% bg = "fw-bold" if possible && matchup.finished? %>
 <% current_user_pick = current_user_round&.picks_by_matchup_id&.[](matchup.id) %>
 <% is_user_pick = current_user_pick&.winner == winner && current_user_pick&.num_games == num_games %>
-<td class="text-end text-nowrap <%= bg %>"><% if is_user_pick %><span class="user-pick-dot" title="Your pick"></span><% end %><%= winner.short_name %> in <%= num_games %></td>
+<td class="text-end text-nowrap <%= bg %>"><% if is_user_pick %><span class="user-pick-dot" title="Your pick"></span><% end %><%= team_logo_tag(winner, size: 28) || winner.short_name %> <span class="text-body-tertiary" style="font-size: 0.75em;">in</span> <%= num_games %></td>
 <td class="align-middle <%= 'opacity-25' unless possible %>" style="min-width: 75px;">
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15" data-bs-toggle="tooltip" data-bs-html="true" title="<%= "#{count} #{"person".pluralize(count)} picked #{winner.name} in #{num_games}." %>">
     <% pct = (count.to_f * 100 / total).round(4) %>

--- a/app/views/round/_matchup_summary_entry.html.erb
+++ b/app/views/round/_matchup_summary_entry.html.erb
@@ -5,7 +5,7 @@
 <% bg = "fw-bold" if possible && matchup.finished? %>
 <% current_user_pick = current_user_round&.picks_by_matchup_id&.[](matchup.id) %>
 <% is_user_pick = current_user_pick&.winner == winner && current_user_pick&.num_games == num_games %>
-<td class="text-end text-nowrap <%= bg %>"><% if is_user_pick %><span class="user-pick-dot" title="Your pick"></span><% end %><%= team_logo_tag(winner, size: 28) || winner.short_name %> <span class="text-body-tertiary" style="font-size: 0.75em;">in</span> <%= num_games %></td>
+<td class="text-end text-nowrap <%= bg %>"><% if is_user_pick %><span class="user-pick-dot" title="Your pick"></span><% end %><%= team_logo_tag(winner, size: 28, class: ("opacity-25" unless possible)) || winner.short_name %> <%= num_games %></td>
 <td class="align-middle <%= 'opacity-25' unless possible %>" style="min-width: 75px;">
   <div class="progress bg-secondary" style="--bs-bg-opacity: .15" data-bs-toggle="tooltip" data-bs-html="true" title="<%= "#{count} #{"person".pluralize(count)} picked #{winner.name} in #{num_games}." %>">
     <% pct = (count.to_f * 100 / total).round(4) %>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -4,7 +4,7 @@
   <% colors = pick.winner.colors %>
   <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px;">
     <%= team_logo_tag(pick.winner, size: 28) || pick.winner.short_name %>
-    <span class="text-body-tertiary" style="font-size: 0.75em;">in</span> <%= pick.num_games %>
+    <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">
     <% width = (matchup.max_possible_points * 100.0 / user_round.biggest_matchup_max_possible).round(4) %>

--- a/app/views/round/_pick_cell.html.erb
+++ b/app/views/round/_pick_cell.html.erb
@@ -3,7 +3,8 @@
 <% if pick %>
   <% colors = pick.winner.colors %>
   <td class="text-end text-nowrap" style="width: 1%; padding-inline: 8px;">
-    <%= pick.winner.short_name %> in <%= pick.num_games %>
+    <%= team_logo_tag(pick.winner, size: 28) || pick.winner.short_name %>
+    <span class="text-body-tertiary" style="font-size: 0.75em;">in</span> <%= pick.num_games %>
   </td>
   <td class="align-middle" style="min-width: 75px;" data-column-index="<%= matchup_index %>" data-sort-value="<%= pick.max_points %>" data-min-points="<%= pick.min_points %>" data-scoring-index="<%= pick.scoring_index %>">
     <% width = (matchup.max_possible_points * 100.0 / user_round.biggest_matchup_max_possible).round(4) %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,19 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+def upsert_matchup!(sport:, year:, round:, conference:, number:, fav:, dog:, fav_wins:, dog_wins:, starts_at:)
+  matchup = Matchup.find_or_initialize_by(
+    sport: sport, year: year, round: round, conference: conference, number: number
+  )
+  matchup.update!(
+    favorite_tricode: fav,
+    underdog_tricode: dog,
+    favorite_wins: fav_wins,
+    underdog_wins: dog_wins,
+    starts_at: starts_at
+  )
+end
+
 # MLB 2021
 [
   [1, :al, 1, :tb, :bos, 1, 3],
@@ -16,17 +29,43 @@
   [2, :nl, 1, :atl, :lad, 4, 2],
   [3, :ws, 1, :hou, :atl, 2, 4]
 ].each do |round, conference, number, fav, dog, fav_wins, dog_wins|
-  Matchup.find_or_create_by!(
-    sport: :mlb,
-    year: 2021,
-    round: round,
-    conference: conference,
-    number: number,
-    favorite_tricode: fav,
-    underdog_tricode: dog,
-    favorite_wins: fav_wins,
-    underdog_wins: dog_wins,
+  upsert_matchup!(
+    sport: :mlb, year: 2021,
+    round: round, conference: conference, number: number,
+    fav: fav, dog: dog, fav_wins: fav_wins, dog_wins: dog_wins,
     starts_at: Date.new(2021, 11, 1)
+  )
+end
+
+# NBA 2026 — mix of completed and in-progress series for UI testing
+[
+  # Round 1 East (completed)
+  [1, :east, 1, :cle, :mia, 4, 1],
+  [1, :east, 2, :bos, :orl, 4, 2],
+  [1, :east, 3, :nyk, :det, 4, 3],
+  [1, :east, 4, :mil, :ind, 1, 4],
+  # Round 1 West (completed)
+  [1, :west, 1, :okc, :mem, 4, 0],
+  [1, :west, 2, :hou, :gsw, 4, 3],
+  [1, :west, 3, :lal, :min, 1, 4],
+  [1, :west, 4, :den, :lac, 4, 2],
+  # Round 2 East (in progress)
+  [2, :east, 1, :cle, :nyk, 2, 1],
+  [2, :east, 2, :bos, :ind, 3, 2],
+  # Round 2 West (in progress)
+  [2, :west, 1, :okc, :den, 2, 2],
+  [2, :west, 2, :hou, :min, 1, 1],
+  # Conf Finals (not started)
+  [3, :east, 1, :cle, :bos, 0, 0],
+  [3, :west, 1, :okc, :hou, 0, 0],
+  # Finals (not started)
+  [4, :finals, 1, :okc, :cle, 0, 0]
+].each do |round, conference, number, fav, dog, fav_wins, dog_wins|
+  upsert_matchup!(
+    sport: :nba, year: 2026,
+    round: round, conference: conference, number: number,
+    fav: fav, dog: dog, fav_wins: fav_wins, dog_wins: dog_wins,
+    starts_at: Date.new(2026, 4, 19)
   )
 end
 
@@ -60,19 +99,17 @@ usernames = %w[
 ]
 
 usernames.each do |username|
-  user = User.create!(
-    email: "#{username}@taarg.us",
-    username: username,
-    password: SecureRandom.hex
-  )
+  user = User.find_or_create_by!(email: "#{username}@taarg.us") do |u|
+    u.username = username
+    u.password = SecureRandom.hex
+  end
 
   Matchup.all.each do |matchup|
-    user.picks.create!(
-      matchup: matchup,
-      winner_is_favorite: [true, false].sample,
-      num_games: rand(matchup.games_needed_to_win..matchup.max_games)
-    )
+    user.picks.find_or_create_by!(matchup: matchup) do |p|
+      p.winner_is_favorite = [true, false].sample
+      p.num_games = rand(matchup.games_needed_to_win..matchup.max_games)
+    end
   end
-rescue ActiveRecord::RecordInvalid
-  puts "skipping #{username}"
+rescue ActiveRecord::RecordInvalid => e
+  puts "skipping #{username}: #{e.message}"
 end

--- a/spec/lib/team_spec.rb
+++ b/spec/lib/team_spec.rb
@@ -21,6 +21,56 @@ describe Team do
     end
   end
 
+  describe "#colors" do
+    subject { team.colors }
+
+    context "for an NBA team" do
+      let(:team) { described_class.nba(:lal) }
+      it { should eql({primary: "#552583", secondary: "#FDB927"}) }
+    end
+
+    context "for an MLB team (no colors defined)" do
+      let(:team) { described_class.mlb(:nyy) }
+      it { should eql({}) }
+    end
+  end
+
+  describe "#external_id" do
+    context "for an NBA team" do
+      subject { described_class.nba(:nyk).external_id }
+      it { should eql 1610612752 }
+    end
+
+    context "for an MLB team" do
+      subject { described_class.mlb(:nyy).external_id }
+      it { should be_nil }
+    end
+  end
+
+  describe "#logo_url" do
+    context "for an NBA team" do
+      let(:team) { described_class.nba(:nyk) }
+
+      it "defaults to the light variant" do
+        expect(team.logo_url).to eql "https://cdn.nba.com/logos/nba/1610612752/primary/L/logo.svg"
+      end
+
+      it "returns the dark variant when requested" do
+        expect(team.logo_url(theme: :dark)).to eql "https://cdn.nba.com/logos/nba/1610612752/primary/D/logo.svg"
+      end
+
+      it "accepts string themes" do
+        expect(team.logo_url(theme: "dark")).to include "/D/"
+      end
+    end
+
+    context "for an MLB team without an external_id" do
+      it "returns nil" do
+        expect(described_class.mlb(:nyy).logo_url).to be_nil
+      end
+    end
+  end
+
   describe "::NBA_TEAMS" do
     subject { described_class::NBA_TEAMS }
 


### PR DESCRIPTION
## Summary

- Adds NBA team logo support: maps tricodes to cdn.nba.com team IDs, exposes `Team#logo_url(theme:)` and a theme-reactive `team_logo_tag` view helper that renders both light/dark variants and lets CSS swap them based on `data-bs-theme`.
- Refactors the team data into per-team keyword-arg hashes so `Team.new(tc, **attrs)` does the work; `colors` is now a stored attribute and the parallel `NBA_COLORS` / `NBA_EXTERNAL_IDS` maps are gone.
- Replaces "Cavs in 6"-style text with the team logo + game count in `_pick_cell` and `_matchup_summary_entry`. Falls back to `short_name` when a team has no logo (e.g. MLB), so MLB seasons keep working unchanged.
- Dims impossible-outcome logos in the matchup summary with `opacity-25` to match the adjacent progress bar.
- Seeds: adds NBA 2026 matchups (round 1 complete, round 2 in progress, later rounds not started) and switches matchup/user/pick creation to find-or-update on the unique scope so re-running `db:seed` is idempotent and backfills picks for existing users.

## Why

The first column of each matchup pair previously held variable-width team names, causing per-row jitter. Logos give every row a fixed-width visual and stronger team identity. The seed change was needed to actually see the new UI in development with realistic NBA data.

## Notes for review

- `Team#logo_url` currently hardcodes the cdn.nba.com URL pattern. MLB logos are out of scope here — they need a different URL pattern (mlbstatic.com) and either a sport attr on `Team` or a per-team URL pattern. The fallback path keeps MLB views working in the meantime.
- The dark/light swap is pure CSS (both `<img>` variants render, one is `display: none`). It reacts instantly to live theme toggles, including "follow system."
- New spec coverage in `spec/lib/team_spec.rb` for `#colors`, `#external_id`, and `#logo_url`.

## Test plan

- [ ] `bundle exec rspec` passes
- [ ] `bin/rails db:seed` runs cleanly on a fresh DB *and* on a DB that already has the prior seed data
- [x] Round table: logos render in light mode, swap to dark variants on theme toggle, and follow system theme
- [x] Matchup summary: impossible outcomes show dimmed logos matching the dimmed progress bar; "Your pick" dot still appears
- [x] MLB season pages still render (text fallback in place of logos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)