### PR TITLE
Fix missing opacity on Overall Total striped bar in round tables

### DIFF
--- a/app/views/round/_overall_total_cell.html.erb
+++ b/app/views/round/_overall_total_cell.html.erb
@@ -14,7 +14,7 @@
       <% potential = overall_user.max_total - overall_user.min_total %>
       <% if potential.positive? %>
         <% pct = (potential.to_f / @biggest_max_total * 100).round(4) %>
-        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; --bs-bg-opacity: .5;">
+        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: <%= pct %>%; background-color: <%= rank_color %>; opacity: 0.4;">
           <%= potential %>
         </div>
       <% end %>


### PR DESCRIPTION
## Summary

On the round-table tabs of the standings page (e.g. "Conf Semis"), the **Overall Total** column's progress bar was missing the dimmed-stripes treatment that every other progress bar has — its potential/possible-points portion (the striped part) rendered at full color instead of the faded look used in the **Round Total** column and the matchup columns.

This is a regression from the Design refresh (#158, commit a102850):

- When the Overall Total column was first added (#151), its striped bar used a Bootstrap `bg-*` class plus `--bs-bg-opacity: .5;`. Because Bootstrap's `bg-*` colors are defined as `rgba(var(--bs-{color}-rgb), var(--bs-bg-opacity))`, the variable actually dimmed the color. ✅
- The design refresh switched all progress bars from Bootstrap `bg-*` classes to inline `background-color: hsl(...)` (rank-based color). For `_total_cell.html.erb` it correctly swapped `--bs-bg-opacity: .5` for `opacity: 0.4`. For `_overall_total_cell.html.erb` the swap was missed — `--bs-bg-opacity: .5;` stayed but is now a no-op against the inline `background-color`. ❌

Fix: one-line change to use `opacity: 0.4;`, matching the sibling Round Total partial.

## Test plan

- [ ] Run `bin/rails server` + `bin/webpack-dev-server`.
- [ ] Open standings, click into a round tab (e.g. "Conf Semis").
- [ ] Confirm the striped portion of bars in the **Overall Total** column now appears dimmed, matching the Round Total column.
- [ ] Confirm the solid (locked-in) portion still renders at full color.
- [ ] Spot-check the Overall tab and matchup columns to confirm nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)