### PR TITLE
Prevent Score column from wrapping at en-dash

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,6 +33,7 @@ th:nth-child(2), td:nth-child(2) {
 
 .table-score-col {
   text-align: center;
+  white-space: nowrap;
 }
 
 .table-breakdown-col {


### PR DESCRIPTION
## Summary

- Score values like \`49–109\` were wrapping to two lines on desktop because the en-dash is a soft line-break opportunity, and the auto-layout was giving the Score column just enough width to break there.
- Mobile didn't show the bug because \`.table-responsive\` lets the table overflow horizontally, so the cell sized to content.
- Adds \`white-space: nowrap\` to \`.table-score-col\` so the cell sizes to its (≤6 char) content on every viewport. No other width tweaks needed.

## Test plan

- [ ] Standings page → Overall tab on desktop: Score column is single-line and no wider than needed
- [ ] Same at mobile width: Score still single-line, Breakdown still gets the bulk of the width
- [ ] First Round and Conf Semis tabs look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)