### PR TITLE
Fix Overall standings table overflow on wider viewports

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,7 +24,8 @@ th:nth-child(2), td:nth-child(2) {
   max-width: 10vw;
 }
 
-.table-name-col {
+.table-name-col span {
+  display: inline-block;
   max-width: 20vw;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -37,7 +38,7 @@ th:nth-child(2), td:nth-child(2) {
 }
 
 .table-breakdown-col {
-  min-width: 50vw;
+  width: 100%;
 }
 
 .table tbody td,

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -54,9 +54,9 @@ development:
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false
-    host: localhost
+    host: 127.0.0.1
     port: 3035
-    public: localhost:3035
+    public: 127.0.0.1:3035
     hmr: false
     # Inline should be set to true if using HMR
     inline: true


### PR DESCRIPTION
## Summary

The Overall standings table on desktop scrolled horizontally (with the sticky Name column overlapping Score) at wider viewport widths — and counterintuitively, narrower windows fit fine. Two small fixes plus an unrelated dev-environment fix.

## What changed

**`app/assets/stylesheets/application.css`** — two minimal tweaks vs. the previous rules:

1. Move name-column truncation onto the inner `<span>` with `display: inline-block`. `max-width` on a `<td>` is largely ignored in auto-layout tables, so long usernames (e.g. `If he aint dead, don't interrupt my basketball`) blew past `max-width: 20vw` and expanded the cell. Applied to an inline-block span, `max-width` is reliably enforced.
2. Change `.table-breakdown-col` from `min-width: 50vw` to `width: 100%`. The page sits inside Bootstrap's `.container` (capped at 1320px), but `50vw` scales with the viewport — so on wide windows breakdown demanded more space than the container had, forcing horizontal scroll. `width: 100%` lets breakdown absorb whatever space is left in the container at any viewport size.

**`config/webpacker.yml`** — bind webpack-dev-server to `127.0.0.1` instead of `localhost`. Node 17+ resolves `localhost` to `::1` (IPv6) by default, while Rails proxies to `127.0.0.1` (IPv4), causing `EOFError` on `/packs/*` requests when running on a newer Node. Pinning to `127.0.0.1` keeps both ends on IPv4 regardless of Node version.

## Reviewer notes

- The `.table-name-col span` selector applies to the round tables too (they share `_user_cell.html.erb`). Behavior there is unchanged in practice — round tables already scrolled horizontally due to many matchup columns, and now their long usernames also truncate cleanly.
- Bootstrap's tooltip on the username span is unaffected; the full name still appears on hover.

## Test plan

- [x] Visit `/standings` (Overall tab). Resize the window from narrow to ultra-wide — table stays inside the container at every width, no horizontal scrollbar.
- [x] At narrow widths the long username truncates with `…`; tooltip still shows the full name.
- [x] First Round / Conf Semis / Conf Finals / Finals tabs render normally.
- [x] Dark mode: sticky name column still has correct background.
- [x] Local: `bin/webpack-dev-server` + `bin/rails server` on Node ≥17 — no more `EOFError` on `/packs/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)