### PR TITLE
Send Referer header when fetching NBA bracket JSON

### DIFF
--- a/app/lib/sync/nba/client.rb
+++ b/app/lib/sync/nba/client.rb
@@ -18,7 +18,8 @@ module Sync
       attr_reader :year
 
       def connection
-        @connection ||= Faraday.new(url: url) do |f|
+        # The CDN started returning 403 to requests without a Referer header in 2026.
+        @connection ||= Faraday.new(url: url, headers: {"Referer" => "https://www.nba.com/"}) do |f|
           f.response :json, content_type: content_types, parser_options: {symbolize_names: true}
           f.response :raise_error
         end


### PR DESCRIPTION
## Summary
- The scheduled `Sync::Nba::Matchups` job started failing with `Faraday::ForbiddenError: 403` on `https://cdn.nba.com/static/json/staticData/brackets/<year>/PlayoffBracket.json`.
- The NBA CDN now rejects requests that don't include a `Referer` header. nba.com itself still calls this same endpoint and gets a 200 because the browser sends a Referer.
- Verified via curl that `Referer: https://www.nba.com/` alone is sufficient — User-Agent and Origin are not required.

## Test plan
- [ ] `rake` task that runs `Sync::Nba::Matchups` succeeds against prod CDN
- [ ] Heroku scheduler run completes without a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)