### PR TITLE
Adopt indigo as the brand primary; refactor standings tab CSS

### DIFF
--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -128,16 +128,17 @@
 // readable on both light and dark backgrounds without per-theme
 // overrides. Active text falls back to the body color so it's legible
 // on the new tint (Bootstrap's default white would disappear).
-#standingsTabs .nav-link {
-  color: var(--bs-secondary-color);
+//
+// Driven through Bootstrap's documented nav CSS variables where they
+// exist; see https://getbootstrap.com/docs/5.3/components/navs-tabs/#css.
+#standingsTabs {
+  --bs-nav-link-color: var(--bs-secondary-color);
+  --bs-nav-link-hover-color: var(--bs-body-color);
+  --bs-nav-pills-link-active-color: var(--bs-body-color);
+  --bs-nav-pills-link-active-bg: rgba(99, 102, 241, 0.15);
+}
 
-  &.active {
-    background-color: rgba(99, 102, 241, 0.15);
-    color: var(--bs-body-color);
-  }
-
-  &:not(.active):hover {
-    background-color: rgba(99, 102, 241, 0.08);
-    color: var(--bs-body-color);
-  }
+// Bootstrap has no nav-link hover-bg variable, so this stays a direct rule.
+#standingsTabs .nav-link:not(.active):hover {
+  background-color: rgba(99, 102, 241, 0.08);
 }

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -122,23 +122,30 @@
   background-color: rgba(0, 97, 100, var(--bs-bg-opacity)) !important;
 }
 
-// Modern selected/hover treatment for the standings tabs: a soft
-// indigo tint instead of Bootstrap's default solid blue pill, with a
-// lighter shade of the same hue on hover. Low opacity keeps the fill
-// readable on both light and dark backgrounds without per-theme
-// overrides. Active text falls back to the body color so it's legible
-// on the new tint (Bootstrap's default white would disappear).
+// Modern selected/hover treatment for the standings tabs: a soft indigo
+// tint instead of Bootstrap's default solid blue pill, with a lighter
+// shade of the same hue on hover. Active text falls back to the body
+// color so it's legible on the tint (Bootstrap's default white would
+// disappear).
 //
 // Driven through Bootstrap's documented nav CSS variables where they
 // exist; see https://getbootstrap.com/docs/5.3/components/navs-tabs/#css.
+//
+// Deliberately indigo-500, one shade lighter than the indigo-600 $primary
+// used for buttons. The button needs the darker shade to keep white text
+// above Bootstrap's 4.5 contrast threshold, but the pill is a low-opacity
+// tint where the lighter shade reads better and works at a single opacity
+// in both light and dark modes.
+$nav-pill-accent: #6366F1;
+
 #standingsTabs {
   --bs-nav-link-color: var(--bs-secondary-color);
   --bs-nav-link-hover-color: var(--bs-body-color);
   --bs-nav-pills-link-active-color: var(--bs-body-color);
-  --bs-nav-pills-link-active-bg: rgba(99, 102, 241, 0.15);
+  --bs-nav-pills-link-active-bg: #{rgba($nav-pill-accent, 0.15)};
 }
 
 // Bootstrap has no nav-link hover-bg variable, so this stays a direct rule.
 #standingsTabs .nav-link:not(.active):hover {
-  background-color: rgba(99, 102, 241, 0.08);
+  background-color: rgba($nav-pill-accent, 0.08);
 }

--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -59,8 +59,7 @@ class StandingsController < ApplicationController
       matchups: matchups,
       user_data: user_data,
       show_totals: matchups.length > 1,
-      num_outcomes: matchups.first.games_needed_to_win * 2,
-      bg_color: BG_COLORS[n]
+      num_outcomes: matchups.first.games_needed_to_win * 2
     }
   end
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,12 @@
+// Brand color. Overriding $primary before the Bootstrap import propagates
+// indigo to btn-primary, links, focus rings, and the standings nav pills
+// (which reference --bs-primary-rgb), so the accent is defined in one place.
+// indigo-600 (not the lighter indigo-500 #6366F1): #6366F1 sits at 4.47:1
+// against white, just under Bootstrap's 4.5 contrast threshold, so buttons
+// would flip to dark text. #4F46E5 keeps white button text and reads better
+// as link text on light backgrounds.
+$primary: #4F46E5;
+
 @import "~bootstrap/scss/bootstrap";
 
 // Flip Bootstrap's default inverted tooltips so they match the active theme:


### PR DESCRIPTION
Samples of the new primary color:

<img width="488" height="708" alt="Screenshot 2026-05-30 at 10 56 52 PM" src="https://github.com/user-attachments/assets/43965833-0054-4ef5-bf27-f9d059f719b0" />
<img width="507" height="692" alt="Screenshot 2026-05-30 at 10 57 05 PM" src="https://github.com/user-attachments/assets/bdabc404-3486-41d1-a8b1-517062bb3b55" />


## Summary

Adopts a single brand color (indigo) for the app's Bootstrap primary, and tidies up the standings tab styling that landed in #178.

**The only visible/functional change is the primary color → indigo-600 (`#4F46E5`).** Everything else is refactor or dead-code cleanup with no rendered change.

## What changes visibly

Overriding Bootstrap's `$primary` propagates indigo to everything that uses the primary color:

- `btn-primary` submit buttons on picks and the Devise (sign in / password / account) views
- link color and focus rings app-wide

These go from Bootstrap's default blue (`#0d6efd`) to indigo. White button text is preserved — indigo-600 clears Bootstrap's 4.5 contrast threshold (the lighter indigo-500 sits at 4.47 and would flip buttons to dark text).

The **standings nav pills render identically** to before — they stay on indigo-500 via a named `$nav-pill-accent`, since the pill is a low-opacity tint (with body-color text) where the button-contrast concern doesn't apply and the lighter shade reads better in both light and dark mode.

## What doesn't change visibly

- **Nav tab CSS refactor** — the hardcoded `.nav-link` color rules from #178 are now expressed through Bootstrap's documented nav CSS variables (`--bs-nav-link-color`, `--bs-nav-pills-link-active-*`, etc.; see the [Bootstrap navs docs](https://getbootstrap.com/docs/5.3/components/navs-tabs/#css)). Same computed values, so no pixel change. The one effect Bootstrap has no variable for (hover background on inactive tabs) stays a direct rule.
- **Dead-code cleanup** — `build_round_data` set a `bg_color:` hash key that nothing has read since the Design refresh (#158) moved the round-table cells to inline rank/team colors. Removed.

## Commits

1. `04d3c69` Refactor standings tab styling to Bootstrap nav CSS variables (no visible change)
2. `9615372` Make indigo the Bootstrap primary; keep nav pill on indigo-500 (**the visible change**)
3. `e0c29d1` Remove dead bg_color key from round data (no visible change)

## Testing

- Standings: nav pills look unchanged in both light and dark mode; active/hover tints match prior behavior.
- Picks (`/picks`, `/picks/new`), Devise sign-in / account pages: submit buttons are now indigo with white text.
- Links and focus rings reflect the new indigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
