### PR TITLE
Switch overall standings round bars to Knicks team colors

### DIFF
--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -101,25 +101,27 @@
   color: var(--bs-secondary-color);
 }
 
-// Round bar palette: colorblind-friendly diverging scheme from
-// Andy Kirk's "Red-green variation #1" (visualisingdata.com). The
-// neutral cream midpoint (#E6E1BC) is omitted since it's invisible on
-// a light background.
+// Round bar palette: New York Knicks team colors, ramped light-to-dark
+// toward the Finals (round 4). The two light bars (silver, orange) get
+// dark text so the points number stays legible; the dark bars (blue,
+// black) keep the progress bar's default white text.
 .bg-round-1 {
   --bs-bg-opacity: 0.85;
-  background-color: rgba(219, 67, 37, var(--bs-bg-opacity)) !important;
+  background-color: rgba(190, 192, 194, var(--bs-bg-opacity)) !important; // Silver #BEC0C2
+  color: #000;
 }
 .bg-round-2 {
   --bs-bg-opacity: 0.85;
-  background-color: rgba(237, 162, 71, var(--bs-bg-opacity)) !important;
+  background-color: rgba(245, 132, 38, var(--bs-bg-opacity)) !important; // Knicks Orange #F58426
+  color: #000;
 }
 .bg-round-3 {
   --bs-bg-opacity: 0.85;
-  background-color: rgba(87, 196, 173, var(--bs-bg-opacity)) !important;
+  background-color: rgba(0, 107, 182, var(--bs-bg-opacity)) !important; // Knicks Blue #006BB6
 }
 .bg-round-4 {
   --bs-bg-opacity: 0.85;
-  background-color: rgba(0, 97, 100, var(--bs-bg-opacity)) !important;
+  background-color: rgba(0, 0, 0, var(--bs-bg-opacity)) !important; // Black #000000
 }
 
 // Modern selected/hover treatment for the standings tabs: a soft indigo

--- a/app/assets/stylesheets/standings.scss
+++ b/app/assets/stylesheets/standings.scss
@@ -101,25 +101,47 @@
   color: var(--bs-secondary-color);
 }
 
-// Round bar palette: New York Knicks team colors, ramped light-to-dark
-// toward the Finals (round 4). The two light bars (silver, orange) get
-// dark text so the points number stays legible; the dark bars (blue,
-// black) keep the progress bar's default white text.
+// Round bar palette: colorblind-friendly diverging scheme from
+// Andy Kirk's "Red-green variation #1" (visualisingdata.com). The
+// neutral cream midpoint (#E6E1BC) is omitted since it's invisible on
+// a light background. Used for all past-season standings.
 .bg-round-1 {
+  --bs-bg-opacity: 0.85;
+  background-color: rgba(219, 67, 37, var(--bs-bg-opacity)) !important;
+}
+.bg-round-2 {
+  --bs-bg-opacity: 0.85;
+  background-color: rgba(237, 162, 71, var(--bs-bg-opacity)) !important;
+}
+.bg-round-3 {
+  --bs-bg-opacity: 0.85;
+  background-color: rgba(87, 196, 173, var(--bs-bg-opacity)) !important;
+}
+.bg-round-4 {
+  --bs-bg-opacity: 0.85;
+  background-color: rgba(0, 97, 100, var(--bs-bg-opacity)) !important;
+}
+
+// New York Knicks team colors, used only for the active season's overall
+// standings (see StandingsController). Ramped light-to-dark toward the
+// Finals (round 4). The two light bars (silver, orange) get dark text so
+// the points number stays legible; the dark bars (blue, black) keep the
+// progress bar's default white text.
+.bg-round-knicks-1 {
   --bs-bg-opacity: 0.85;
   background-color: rgba(190, 192, 194, var(--bs-bg-opacity)) !important; // Silver #BEC0C2
   color: #000;
 }
-.bg-round-2 {
+.bg-round-knicks-2 {
   --bs-bg-opacity: 0.85;
   background-color: rgba(245, 132, 38, var(--bs-bg-opacity)) !important; // Knicks Orange #F58426
   color: #000;
 }
-.bg-round-3 {
+.bg-round-knicks-3 {
   --bs-bg-opacity: 0.85;
   background-color: rgba(0, 107, 182, var(--bs-bg-opacity)) !important; // Knicks Blue #006BB6
 }
-.bg-round-4 {
+.bg-round-knicks-4 {
   --bs-bg-opacity: 0.85;
   background-color: rgba(0, 0, 0, var(--bs-bg-opacity)) !important; // Black #000000
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,15 @@ class ApplicationController < ActionController::Base
     bg-round-4
   ].freeze
 
+  # Knicks team colors, used only for the active season's overall standings.
+  KNICKS_BG_COLORS = %w[
+    not-used
+    bg-round-knicks-1
+    bg-round-knicks-2
+    bg-round-knicks-3
+    bg-round-knicks-4
+  ].freeze
+
   protected
 
   # :nocov:

--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -30,7 +30,8 @@ class StandingsController < ApplicationController
     # Hash of round numbers to names
     @round_names = picks.map(&:matchup).uniq(&:round).to_h { |m| [m.round, m.round_name] }
 
-    @bg_colors = BG_COLORS
+    current_season = CurrentSeason.sport_year == [params[:sport]&.to_sym, params[:year]&.to_i]
+    @bg_colors = current_season ? KNICKS_BG_COLORS : BG_COLORS
 
     @show_overall_total = @rounds.length > 1
 


### PR DESCRIPTION
Replace the colorblind-friendly red→teal ramp with a light-to-dark Knicks palette toward the Finals: silver, orange, blue, black. The two light bars get dark text so the points number stays legible.